### PR TITLE
实现筛选切换动画

### DIFF
--- a/#23筛选切换动画分支/#23筛选切换动画计划.md
+++ b/#23筛选切换动画分支/#23筛选切换动画计划.md
@@ -1,0 +1,336 @@
+# #23 筛选切换动画实施计划（修正版）
+
+## Summary
+
+本轮目标是把「只看有图 / 只看收藏 / 切分类 / 清除筛选」从瞬间清屏重绘，改成更顺滑的短过渡：旧的可见卡片短暂淡出，新列表首屏卡片统一淡入。
+
+根据 Claude / GLM 审阅意见，修正版做三处关键调整：
+
+- 不在 CSS class 里写 `transform`。当前卡片定位是 `updateCardPosition()` 写入的 inline transform，class transform 覆盖不了。筛选离场只用 class 控制 `opacity`，位移通过修改 `--entry-offset` 让现有 inline transform 读取。
+- 不新增独立筛选入场 class。筛选入场复用现有 `maybeAnimateCardEntry()`，通过模块级 `forceEntryAnim` 临时强制首屏新卡片统一入场，避免和 `seenAnimated` / `.card-enter` 打架。
+- 深滚动时不播放旧卡片离场动画。用户已经滚到很深处时，筛选本身会回到顶部，离场动画只会制造额外抖动；第一版仅在接近顶部时播放旧卡片离场，其他场景同步重绘并让新首屏正常入场。
+
+不做完整 FLIP，不改 `computeLayout()`、虚拟 buffer、图片高度估算、图片 fallback 和密度重排路径。
+
+## Scope
+
+纳入动画：
+
+- 顶栏「只看有图」开关。
+- 顶栏「只看收藏」开关。
+- 目录树分类切换。
+- 顶部分类胶囊切换。
+- 面包屑路径点击（实际会走 `selectPath()`，和目录 / 胶囊保持一致）。
+- 空状态按钮触发的清除筛选 / 关闭只看有图 / 去浏览全部。
+- 搜索清空按钮。它是一次性清除动作，语义接近清除筛选，和逐字搜索不同。
+- 「只看收藏」开启时，取消收藏导致当前列表变化的路径。
+
+暂不纳入：
+
+- 法典切换：保持骨架 / 加载路径，不和筛选动画混合。
+- 搜索逐字输入：180ms debounce 下频繁触发，逐字动画会拖慢搜索。
+- 最近浏览恢复、深链接打开、随机探索、密度切换、resize：这些属于导航或布局重排，不走筛选离场动画。
+- NSFW / R18G 开关：涉及内容准入与确认弹窗，保持状态切换明确，不加装饰动效。
+
+## Current Code Facts
+
+- `site/assets/app.js`
+  - `applyFilter(options = {})` 负责计算 `state.list`，然后调用 `renderList(options)`。
+  - 当前筛选后立即 `updateResultBar()` + `renderList({ resetScroll: true })`。
+
+- `site/assets/app/masonry.js`
+  - `renderList()` 当前直接 `clearMasonry()`、可选滚动到顶部、`computeLayout()`、`updateVirtualCards(true)`、`updateScrollProgress()`。
+  - `clearMasonry()` 会清理所有卡片节点和图片 timer，并移除 `is-relayouting`。
+  - `updateCardPosition()` 给每张卡写入 inline transform：
+
+```js
+node.style.transform = 'translate3d(var(--card-x), calc(var(--card-y) + var(--entry-offset, 0px)), 0)';
+```
+
+  - 因此筛选动画不能依赖 `.some-class { transform: ... }`。
+  - `makeCard()` 里已有 `maybeAnimateCardEntry()`，使用 `state.seenAnimated` 防止普通滚动重复入场。
+  - 密度切换已有 `is-relayouting` / `relayoutAnimating` 路径，不复用给筛选动画。
+
+- `site/assets/styles.css`
+  - `.card` 已有 `opacity` / `transform` transition。
+  - `.card.card-enter` 是当前卡片入场动画。
+  - `prefers-reduced-motion` 已集中处理，新类要并入这个兜底。
+
+## Key Decisions
+
+### 1. 显式 opt-in
+
+新增约定：
+
+```js
+applyFilter({ resetScroll: true, transition: 'filter' })
+```
+
+只有明确传入 `transition: 'filter'` 时启用筛选动画。默认仍是同步重绘，保护初始化、法典切换、历史恢复、深链接和搜索输入。
+
+### 2. 离场只做 opacity + `--entry-offset`
+
+离场 class 只写能覆盖 inline style 的属性：
+
+```css
+.card.card-leaving{
+  opacity:0;
+  transition-delay:var(--filter-delay,0ms);
+}
+```
+
+位移在 JS 里通过变量完成：
+
+```js
+node.style.setProperty('--entry-offset', '10px');
+node.style.setProperty('--filter-delay', `${delay}ms`);
+node.classList.add('card-leaving');
+```
+
+第一版不做 scale。若未来要 scale，应先调整 `updateCardPosition()` 的 inline transform 公式，例如加入 `scale(var(--card-scale, 1))`，不能直接写在 class 里。
+
+### 3. 入场复用 `maybeAnimateCardEntry()`
+
+不新增 `.card-filter-enter`。
+
+在 `masonry.js` 增加模块级状态：
+
+```js
+let filterTransitionSeq = 0;
+let filterTransitionTimer = 0;
+let forceEntryAnim = false;
+```
+
+调整 `maybeAnimateCardEntry()`：
+
+```js
+if (prefersReducedMotion() || relayoutAnimating || !state.codex) return;
+const key = `${state.codex.id}:${placement.entry.id}`;
+if (!forceEntryAnim && state.seenAnimated.has(key)) return;
+state.seenAnimated.add(key);
+// 后续沿用现有 card-enter / is-entered / --entry-offset 逻辑
+```
+
+筛选重绘时短暂置 `forceEntryAnim = true`，让首屏新卡片即使已在 `seenAnimated` 中，也统一执行一次入场。执行后仍写回 `seenAnimated`，避免筛选结束后上下滚动反复入场。
+
+### 4. 深滚动门限
+
+新增判断：
+
+```js
+function isNearFilterTop() {
+  return window.scrollY <= Math.min(window.innerHeight * 0.75, 640);
+}
+```
+
+仅当接近顶部时播放旧卡片离场。
+
+深滚动切筛选时走同步清屏重绘，但仍可在新首屏启用 `forceEntryAnim`，让回顶后的新卡片保持统一入场。这样避免「先跳顶、旧卡片又淡出」的错乱。
+
+### 5. pointer 封锁只覆盖离场段
+
+`.masonry.is-filtering` 只在旧卡片离场阶段存在，约 140-220ms。重绘出新卡片后立即移除，让用户可以快速点击新卡片，不把整个 300ms 入场期都吃掉。
+
+`clearMasonry()` 需要兜底移除：
+
+```js
+m.classList.remove('is-relayouting', 'is-filtering');
+```
+
+同时清理旧的 `filterTransitionTimer`、`card-leaving`、`--filter-delay`、`--entry-offset` 等临时状态。
+
+## ApplyFilter 调用点清单
+
+| 调用点 | 场景 | 是否加 `transition:'filter'` | 理由 |
+|---|---|---:|---|
+| `app.js:109` | `loadCodex()` 法典加载完成 | 否 | 法典切换走加载 / 骨架路径 |
+| `ui.js:86` | 搜索逐字输入 | 否 | 高频 debounce，动画会拖慢搜索 |
+| `ui.js:98` | 搜索清空按钮 | 是 | 一次性清除动作，语义接近清除筛选 |
+| `ui.js:104` | 只看有图 | 是 | 核心筛选入口 |
+| `ui.js:105` | 只看收藏 | 是 | 核心筛选入口 |
+| `ui.js:331` | R18G 开关后重滤 | 否 | 内容准入切换，保持明确直接 |
+| `codex-ui.js:213` | `selectPath()` 分类 / 胶囊 / 面包屑 | 是 | 核心分类切换入口 |
+| `codex-ui.js:352` | 空状态动作 | 是 | 清除筛选 / 回到全部 |
+| `favorites.js:37` | 只看收藏中切收藏状态 | 是 | 当前筛选列表变化 |
+| `history.js:214` | 继续上次浏览 | 否 | 恢复状态应快速准确 |
+| `history.js:289` | 最近浏览打开 | 否 | 导航动作，不是筛选交互 |
+| `router.js:82` | 深链接 entry 定位时补路径 | 否 | 深链接应稳定定位，不播放筛选离场 |
+
+实施时用这张表逐项改动，避免漏加或误加。
+
+## Proposed Flow
+
+### 同步路径
+
+以下情况走原同步路径：
+
+- `transition !== 'filter'`
+- `prefersReducedMotion()`
+- `!state.codex`
+- `#masonry` 不存在
+- 骨架可见或主加载中
+- 灯箱正在打开
+- 当前没有可见旧卡片
+- 非 near-top 且不需要新首屏强制入场时
+
+同步路径仍保持：
+
+```js
+clearMasonry();
+if (resetScroll) window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+computeLayout();
+updateVirtualCards(true);
+updateScrollProgress();
+```
+
+### 筛选路径：near-top
+
+1. `filterTransitionSeq++`，取消上一轮 timer。
+2. 给 `#masonry` 加 `.is-filtering`。
+3. 遍历当前 `state.nodes` 中仍连接的卡片：
+   - 设置 `--filter-delay`，做轻微 stagger。
+   - 设置 `--entry-offset: 10px`。
+   - 添加 `.card-leaving`。
+4. 等待离场完成。第一版可用保守 timeout：`maxDelay + exitMs + 24ms`；如果实现复杂度可控，可用 `transitionend` + timeout 兜底。
+5. seq 未过期时：
+   - 移除 `.is-filtering`。
+   - `clearMasonry()`。
+   - 如果 `resetScroll`，回到顶部。
+   - `computeLayout()`。
+   - `forceEntryAnim = true`。
+   - `updateVirtualCards(true)`。
+   - `forceEntryAnim = false`。
+   - `updateScrollProgress()`。
+
+### 筛选路径：deep-scroll
+
+1. 不播放旧卡片离场。
+2. `clearMasonry()`。
+3. `resetScroll` 时直接回顶部。
+4. `computeLayout()`。
+5. `forceEntryAnim = true`。
+6. `updateVirtualCards(true)`。
+7. `forceEntryAnim = false`。
+8. `updateScrollProgress()`。
+
+这个路径牺牲旧卡片离场，但避免深滚动回顶时的视觉错乱。
+
+## CSS Plan
+
+新增：
+
+```css
+.masonry.is-filtering{
+  pointer-events:none;
+}
+
+.card.card-leaving{
+  opacity:0;
+  transition-delay:var(--filter-delay,0ms);
+}
+```
+
+reduced-motion 中加入：
+
+```css
+.card.card-leaving{
+  transition:none;
+}
+```
+
+不新增 `.card-filter-enter`，不写 `.card-leaving { transform: ... }`。
+
+## Implementation Steps
+
+1. 在 `masonry.js` 增加筛选过渡模块级变量：`filterTransitionSeq`、`filterTransitionTimer`、`forceEntryAnim`。
+2. 调整 `clearMasonry()`，兜底取消筛选 timer、移除 `.is-filtering` 和卡片离场临时状态。
+3. 调整 `maybeAnimateCardEntry()`，支持 `forceEntryAnim`。
+4. 改造 `renderList({ resetScroll = false, transition = 'none' } = {})`：
+   - 默认同步路径不变。
+   - `transition:'filter'` 时进入 near-top / deep-scroll 两种筛选路径。
+5. 在 `styles.css` 增加 `.is-filtering`、`.card-leaving` 和 reduced-motion 兜底。
+6. 按「ApplyFilter 调用点清单」逐项修改调用参数。
+7. 确认搜索输入、法典切换、历史恢复、最近浏览、深链接、R18G 开关没有误加筛选动画。
+8. 跑静态检查和 #26 回归脚本。
+
+## Edge Cases
+
+- 快速连续点击筛选：
+  - `filterTransitionSeq` 作版本号。
+  - 后一次筛选取消前一次 timer。
+  - 旧回调发现 seq 不匹配直接退出。
+
+- 筛选后结果为空：
+  - 旧卡片离场后正常 `clearMasonry()`。
+  - `updateEmptyState()` 保持现有逻辑。
+  - 空状态本身不做复杂动画。
+
+- 用户在动画中滚动：
+  - near-top 离场时间很短，只禁卡片点击，不禁页面滚动。
+  - deep-scroll 不播放旧卡片离场。
+
+- 图片加载 timer：
+  - 离场阶段仍使用真实旧节点，时间短。
+  - 重绘时继续走 `clearMasonry()`，保留 `cleanupCard(node)` 对 `_imageTimer` 的清理。
+
+- 收藏按钮：
+  - 不在「只看收藏」筛选下，只更新按钮状态，不触发列表动画。
+  - 在「只看收藏」下取消收藏，当前可见卡片离场后重绘。
+
+- 灯箱来源图：
+  - 离场阶段禁卡片 pointer events，避免点到即将移除的旧节点并产生错误 FLIP source。
+
+## Test Plan
+
+静态检查：
+
+- `node --check site/assets/app.js`
+- `node --check site/assets/app/*.js`
+- `git diff --check`
+
+调用点专项：
+
+- 覆盖所有 `applyFilter` 调用点，确认每处动画行为符合上表。
+
+人工验证：
+
+- 桌面端切「只看有图」：旧首屏短淡出，新首屏统一淡入，无白屏。
+- 桌面端切「只看收藏」：收藏列表正常；取消收藏时卡片离场，不误开灯箱。
+- 目录树切分类：顶部回到新分类首屏，卡片过渡不横跳。
+- 顶部胶囊和面包屑切分类：移动端和桌面端都无横向抖动。
+- 搜索逐字输入：仍保持当前响应速度，不出现每个字都动画。
+- 搜索清空按钮：一次性过渡，列表恢复正常。
+- 空状态按钮：清除筛选后列表正常恢复，空状态不残留。
+- 法典切换：仍走骨架 / 加载路径，不出现筛选离场动画。
+- 密度切换：仍走 `is-relayouting`，不叠加筛选动画。
+- 深滚动切筛选：不出现「顶部卡片新建后又淡出」或明显抖动。
+- 快速连续点击多个筛选：最终只保留最后一次结果，无残留 `.is-filtering` / `.card-leaving` / `--filter-delay`。
+- 切完筛选后上下滚动：已展示过的卡片不会反复重新淡入。
+- 切筛选后立刻点击新卡片：入场期点击不被长时间吃掉。
+- `prefers-reduced-motion: reduce`：无离场延迟，列表直接切换。
+
+回归脚本：
+
+- 执行 #26 本地 headless Chrome 回归工具。
+- 重点看桌面首屏、移动端首屏、搜索高亮、深链接灯箱、随机探索、历史恢复、NSFW / R18G 开关。
+
+## Risk Control
+
+- 第一版不做完整 FLIP，不追求旧卡片移动到新位置。
+- 不改 `computeLayout()`、`estimateImageHeight()`、虚拟 buffer 参数。
+- 不新增全局 store / event bus。
+- 不在 CSS class 中写筛选 transform，避免被 inline transform 覆盖。
+- 动画总感知时长控制在 300ms 左右；pointer 封锁只覆盖旧卡片离场段。
+- 所有新 timer 都归 `masonry.js` 管，`clearMasonry()` 和新一轮筛选必须能清掉旧状态。
+
+## Open Questions
+
+1. 离场完成用 timeout 还是 `transitionend`？
+   - 建议第一版用 timeout + seq 兜底，时间短、节点数量多，代码更稳。若实测有截断感，再加 `transitionend`。
+
+2. 深滚动同步重绘时是否强制新首屏入场？
+   - 建议保留。旧卡片离场不播，但新首屏淡入能减少回顶后的突兀感。
+
+3. 结果栏数字是否过渡？
+   - 第一版不做。先只让卡片区动，避免同时动多个区域。
+

--- a/site/assets/app/codex-ui.js
+++ b/site/assets/app/codex-ui.js
@@ -210,7 +210,7 @@ export function selectPath(path, rowEl) {
   document.querySelectorAll('.tree-row.active').forEach(r => r.classList.remove('active'));
   rowEl.classList.add('active');
   if (window.innerWidth <= 600) $('#sidebar').classList.add('closed');
-  codexUiActions.applyFilter({ resetScroll: true });
+  codexUiActions.applyFilter({ resetScroll: true, transition: 'filter' });
   codexUiActions.syncUrlState();
 }
 
@@ -349,7 +349,7 @@ export function handleEmptyAction(action) {
     updateSearchClear();
     renderTree();
   }
-  codexUiActions.applyFilter({ resetScroll: true });
+  codexUiActions.applyFilter({ resetScroll: true, transition: 'filter' });
   codexUiActions.syncUrlState();
 }
 

--- a/site/assets/app/favorites.js
+++ b/site/assets/app/favorites.js
@@ -34,6 +34,6 @@ export function toggleFav(e, btn) {
     btn.title = on ? '取消收藏' : '收藏';
     btn.setAttribute('aria-label', on ? '取消收藏' : '收藏');
   }
-  if (state.onlyFav) favoriteActions.applyFilter({ resetScroll: true });
+  if (state.onlyFav) favoriteActions.applyFilter({ resetScroll: true, transition: 'filter' });
   toast(on ? `已收藏：${e.title}` : `已取消收藏：${e.title}`);
 }

--- a/site/assets/app/masonry.js
+++ b/site/assets/app/masonry.js
@@ -17,7 +17,6 @@ const masonryActions = {
 
 const FILTER_EXIT_MS = 140;
 const FILTER_EXIT_PAD_MS = 24;
-const FILTER_EXIT_OFFSET = '10px';
 
 let filterTransitionSeq = 0;
 let filterTransitionTimer = 0;
@@ -41,7 +40,6 @@ function cleanupFilterTransition(m = $('#masonry')) {
   m.querySelectorAll('.card-leaving').forEach(node => {
     node.classList.remove('card-leaving');
     node.style.removeProperty('--filter-delay');
-    node.style.setProperty('--entry-offset', '0px');
   });
 }
 
@@ -154,7 +152,6 @@ export function renderList({ resetScroll = false, transition = 'none' } = {}) {
     const delay = Math.min(90, col * 18 + (index % Math.max(1, state.colN)) * 6);
     maxDelay = Math.max(maxDelay, delay);
     node.style.setProperty('--filter-delay', `${delay}ms`);
-    node.style.setProperty('--entry-offset', FILTER_EXIT_OFFSET);
     node.classList.add('card-leaving');
   }
 

--- a/site/assets/app/masonry.js
+++ b/site/assets/app/masonry.js
@@ -15,8 +15,63 @@ const masonryActions = {
   toggleFav: () => {},
 };
 
+const FILTER_EXIT_MS = 140;
+const FILTER_EXIT_PAD_MS = 24;
+const FILTER_EXIT_OFFSET = '10px';
+
+let filterTransitionSeq = 0;
+let filterTransitionTimer = 0;
+let forceEntryAnim = false;
+
 export function setMasonryActions(actions = {}) {
   Object.assign(masonryActions, actions);
+}
+
+function clearFilterTransitionTimer() {
+  if (!filterTransitionTimer) return;
+  clearTimeout(filterTransitionTimer);
+  filterTransitionTimer = 0;
+}
+
+function cleanupFilterTransition(m = $('#masonry')) {
+  clearFilterTransitionTimer();
+  forceEntryAnim = false;
+  if (!m) return;
+  m.classList.remove('is-filtering');
+  m.querySelectorAll('.card-leaving').forEach(node => {
+    node.classList.remove('card-leaving');
+    node.style.removeProperty('--filter-delay');
+    node.style.setProperty('--entry-offset', '0px');
+  });
+}
+
+function isNearFilterTop() {
+  return window.scrollY <= Math.min(window.innerHeight * 0.75, 640);
+}
+
+function canRunFilterTransition(m, transition) {
+  if (transition !== 'filter' || prefersReducedMotion() || !state.codex || !m) return false;
+  if (state.lightbox?.entry) return false;
+  const main = $('#main');
+  if (main?.classList.contains('has-skeleton') || main?.classList.contains('skeleton-visible')) return false;
+  return [...state.nodes.values()].some(node => node.isConnected);
+}
+
+function canForceFilterEntry(transition) {
+  if (transition !== 'filter' || prefersReducedMotion() || !state.codex) return false;
+  if (state.lightbox?.entry) return false;
+  const main = $('#main');
+  return !(main?.classList.contains('has-skeleton') || main?.classList.contains('skeleton-visible'));
+}
+
+function renderListNow({ resetScroll = false, forceEntry = false } = {}) {
+  clearMasonry();
+  if (resetScroll) window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+  computeLayout();
+  forceEntryAnim = Boolean(forceEntry);
+  updateVirtualCards(true);
+  forceEntryAnim = false;
+  updateScrollProgress();
 }
 
 export function captureMasonryAnchor() {
@@ -53,6 +108,7 @@ export function colCount() {
 }
 
 export function clearMasonry() {
+  cleanupFilterTransition();
   for (const node of state.nodes.values()) cleanupCard(node);
   state.nodes.clear();
   state.placements = [];
@@ -61,18 +117,53 @@ export function clearMasonry() {
   if (m) {
     relayoutAnimating = false;
     clearTimeout(relayoutAnimTimer);
-    m.classList.remove('is-relayouting');
+    m.classList.remove('is-relayouting', 'is-filtering');
     m.innerHTML = '';
     m.style.height = '0px';
   }
 }
 
-export function renderList({ resetScroll = false } = {}) {
-  clearMasonry();
-  if (resetScroll) window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
-  computeLayout();
-  updateVirtualCards(true);
-  updateScrollProgress();
+export function renderList({ resetScroll = false, transition = 'none' } = {}) {
+  const m = $('#masonry');
+  const shouldTransition = canRunFilterTransition(m, transition);
+  const seq = ++filterTransitionSeq;
+  cleanupFilterTransition(m);
+
+  if (!shouldTransition) {
+    renderListNow({ resetScroll, forceEntry: canForceFilterEntry(transition) });
+    return;
+  }
+
+  if (!isNearFilterTop()) {
+    renderListNow({ resetScroll, forceEntry: true });
+    return;
+  }
+
+  const nodes = [...state.nodes.values()].filter(node => node.isConnected);
+  if (!nodes.length) {
+    renderListNow({ resetScroll, forceEntry: true });
+    return;
+  }
+
+  m.classList.add('is-filtering');
+  let maxDelay = 0;
+  for (const node of nodes) {
+    const index = Number(node.dataset.index || 0);
+    const placement = state.placements[index];
+    const col = placement?.col || 0;
+    const delay = Math.min(90, col * 18 + (index % Math.max(1, state.colN)) * 6);
+    maxDelay = Math.max(maxDelay, delay);
+    node.style.setProperty('--filter-delay', `${delay}ms`);
+    node.style.setProperty('--entry-offset', FILTER_EXIT_OFFSET);
+    node.classList.add('card-leaving');
+  }
+
+  filterTransitionTimer = window.setTimeout(() => {
+    filterTransitionTimer = 0;
+    if (seq !== filterTransitionSeq) return;
+    m.classList.remove('is-filtering');
+    renderListNow({ resetScroll, forceEntry: true });
+  }, maxDelay + FILTER_EXIT_MS + FILTER_EXIT_PAD_MS);
 }
 
 export function computeLayout() {
@@ -318,7 +409,7 @@ export function updateCardPosition(node, placement) {
 export function maybeAnimateCardEntry(node, placement) {
   if (prefersReducedMotion() || relayoutAnimating || !state.codex) return;
   const key = `${state.codex.id}:${placement.entry.id}`;
-  if (state.seenAnimated.has(key)) return;
+  if (!forceEntryAnim && state.seenAnimated.has(key)) return;
   state.seenAnimated.add(key);
 
   const delay = Math.min(210, placement.col * 30 + (placement.index % Math.max(1, state.colN)) * 10);

--- a/site/assets/app/ui.js
+++ b/site/assets/app/ui.js
@@ -95,14 +95,14 @@ export function bindUI() {
       state.query = '';
       updateSearchClear();
       renderTree();
-      uiActions.applyFilter({ resetScroll: true });
+      uiActions.applyFilter({ resetScroll: true, transition: 'filter' });
       syncUrlState();
       searchInput.focus();
     };
   }
 
-  $('#onlyImaged').onchange = e => { state.onlyImaged = e.target.checked; uiActions.applyFilter({ resetScroll: true }); };
-  $('#onlyFav').onchange = e => { state.onlyFav = e.target.checked; uiActions.applyFilter({ resetScroll: true }); };
+  $('#onlyImaged').onchange = e => { state.onlyImaged = e.target.checked; uiActions.applyFilter({ resetScroll: true, transition: 'filter' }); };
+  $('#onlyFav').onchange = e => { state.onlyFav = e.target.checked; uiActions.applyFilter({ resetScroll: true, transition: 'filter' }); };
 
   const applyTheme = d => {
     document.body.classList.toggle('dark', d);

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -426,6 +426,7 @@ button.crumb:hover{color:var(--accent);border-color:var(--accent);background:var
 
 /* ---------- 瀑布流 ---------- */
 .masonry{position:relative;min-height:1px;contain:layout paint}
+.masonry.is-filtering{pointer-events:none}
 .col{display:none}
 
 .card{
@@ -435,6 +436,11 @@ button.crumb:hover{color:var(--accent);border-color:var(--accent);background:var
 }
 .card.card-enter{opacity:0;transition-delay:var(--entry-delay,0ms)}
 .card.card-enter.is-entered{opacity:1}
+.card.card-leaving{
+  opacity:0;
+  transition:opacity .14s linear;
+  transition-delay:var(--filter-delay,0ms);
+}
 .masonry.is-relayouting .card{
   transition:
     transform .32s cubic-bezier(.22,1,.36,1),
@@ -587,6 +593,7 @@ body.density-compact .mini-copy{padding:2px 6px;font-size:10.5px}
   .masonry.is-relayouting .card,
   .masonry.is-relayouting .card-img-wrap,
   .masonry.is-relayouting .card-tags,
+  .card.card-leaving,
   .topbar,.sidebar,
   .lightbox,.lightbox-stage,.lightbox-info,.lb-fold,.lb-circle,.lb-fly,#lightboxImg,.lightbox-thumbs,
   .settings-mask,.settings-panel,.sd-badge,.card,.card-img,.toast,.scroll-progress{


### PR DESCRIPTION
## Summary
- 为筛选入口增加显式 opt-in 的切换动画
- near-top 时旧卡片短淡出，新结果首屏统一入场
- 深滚动、法典切换、搜索逐字、历史恢复、深链接等路径保持同步切换
- 最终离场效果调整为纯淡出，避免与卡片入场共用 offset 变量

## Tests
- `node --check site/assets/app.js`
- `node --check site/assets/app/*.js`
- `git diff --check`
- `python tools\verify_ui.py`
- headless 专项探针：near-top 筛选类出现并清理、deep-scroll 不触发离场动画