### PR TITLE
修复关闭浮层时列表滚动闪屏

### DIFF
--- a/site/assets/app/browser-history.js
+++ b/site/assets/app/browser-history.js
@@ -405,9 +405,13 @@ async function handlePopState(event) {
       browserWindow().queueMicrotask(() => requestHistoryBack());
       return;
     }
-  } else {
-    currentEntry = target;
+    /* 纯关浮层：route 已继承自离开记录，界面本来就与之一致。只收敛浮层，
+       跳过路由重放与滚动恢复——否则列表会先被 resetScroll 跳到顶部、再被
+       延迟的滚动恢复弹回原位，产生肉眼可见的闪屏。 */
+    reconcileLayers(target.layers);
+    return;
   }
+  currentEntry = target;
 
   const token = ++restoreToken;
   restoring = true;

--- a/site/assets/app/codex-ui.js
+++ b/site/assets/app/codex-ui.js
@@ -86,7 +86,7 @@ export function setupCodexPicker() {
     menu.hidden = true;
     btn.classList.remove('open');
     btn.setAttribute('aria-expanded', 'false');
-    if (focusButton) btn.focus();
+    if (focusButton) btn.focus({ preventScroll: true });
   };
   registerHistoryLayer('codex-menu', {
     isOpen: () => !menu.hidden,

--- a/site/assets/app/lightbox.js
+++ b/site/assets/app/lightbox.js
@@ -184,7 +184,7 @@ export function closeLightbox(options = {}) {
     img.removeAttribute('src');
     state.lightbox = { entry: null, images: [], index: 0 };
     lbSourceImg = null;
-    if (lbFocusReturn?.isConnected) lbFocusReturn.focus();
+    if (lbFocusReturn?.isConnected) lbFocusReturn.focus({ preventScroll: true });
     lbFocusReturn = null;
   };
   if (options.immediate) {

--- a/site/assets/app/modal.js
+++ b/site/assets/app/modal.js
@@ -54,7 +54,9 @@ function closeMaskDirect(mask) {
   mask.classList.remove('show');
   const restoreFocus = () => {
     const opener = maskOpeners.get(mask);
-    if (opener?.isConnected) opener.focus();
+    /* preventScroll：开启按钮都是顶栏/浮动等视口锚定元素，无需滚动页面去
+       "露出"它；顶栏自动隐藏时浏览器的 scroll-into-view 反而会把列表拉走。 */
+    if (opener?.isConnected) opener.focus({ preventScroll: true });
   };
   if (prefersReducedMotion()) {
     mask.hidden = true;

--- a/site/assets/app/ui.js
+++ b/site/assets/app/ui.js
@@ -92,7 +92,7 @@ export function bindUI() {
       if (focus) requestAnimationFrame(() => searchInput.focus());
     } else {
       searchInput.blur();
-      if (restoreButton) mobileSearchBtn?.focus();
+      if (restoreButton) mobileSearchBtn?.focus({ preventScroll: true });
     }
   };
   registerHistoryLayer('mobile-search', {
@@ -295,7 +295,7 @@ export function bindUI() {
     moreMenu.hidden = true;
     moreBtn.classList.remove('open');
     moreBtn.setAttribute('aria-expanded', 'false');
-    if (focusButton) moreBtn.focus();
+    if (focusButton) moreBtn.focus({ preventScroll: true });
   };
   const openMoreDirect = ({ focus = false } = {}) => {
     closeBannerAbout();

--- a/tools/test_browser_history.mjs
+++ b/tools/test_browser_history.mjs
@@ -311,4 +311,45 @@ assert.equal(replaced.parentId, entry.parentId);
   assert.equal(layerOpen, false);
 }
 
+// A pure layer close only reconciles overlays: no route replay, no scroll
+// restore — the page must not flash to the top when a dialog closes.
+{
+  const win = new FakeWindow();
+  let route = { view: 'all', q: '' };
+  const calls = { applyRoute: 0, restoreScroll: 0 };
+  configureBrowserHistory({
+    window: win,
+    page: 'atlas',
+    captureRoute: () => route,
+    applyRoute: async () => { calls.applyRoute += 1; },
+    restoreScroll: async () => { calls.restoreScroll += 1; },
+  });
+  let dialogOpen = false;
+  registerHistoryLayer('flash-dialog', {
+    isOpen: () => dialogOpen,
+    open: () => { dialogOpen = true; },
+    close: () => { dialogOpen = false; },
+  });
+  const initial = initializeBrowserHistory();
+  win.scrollY = 260;
+  dialogOpen = true;
+  openHistoryLayer('flash-dialog');
+
+  win.history.back();
+  await tick();
+  assert.equal(dialogOpen, false);
+  assert.equal(calls.applyRoute, 0);
+  assert.equal(calls.restoreScroll, 0);
+  assert.equal(win.scrollY, 260);
+  assert.equal(getManagedHistoryEntry().id, initial.id);
+
+  // A real route pop still replays the route and restores scroll.
+  route = { view: 'category', q: '' };
+  commitHistoryRoute({ mode: 'push', transition: 'route' });
+  win.history.back();
+  await tick();
+  assert.equal(calls.applyRoute, 1);
+  assert.equal(calls.restoreScroll, 1);
+}
+
 console.log('browser history tests passed');

--- a/tools/verify_ui.py
+++ b/tools/verify_ui.py
@@ -749,6 +749,29 @@ def run_suite(base_url: str, out_dir: Path, cdp: CDP, only: str = "") -> list[di
         cdp.eval("history.back()")
         wait_for(cdp, "!document.querySelector('#settings')?.classList.contains('show') && history.state?.route?.onlyImaged === false", "reset filter survives close")
 
+        # Closing an overlay must not move the list at all (no flash to top):
+        # record every scroll change while the settings layer closes via back.
+        flash_scroll = cdp.eval("Math.min(500, Math.max(0, document.documentElement.scrollHeight - innerHeight - 20))") or 0
+        cdp.eval(f"scrollTo(0,{int(flash_scroll)})")
+        settle(cdp, 400)
+        cdp.eval(f"scrollTo(0,{int(flash_scroll)})")   # re-assert after masonry relayout settles
+        settle(cdp, 260)
+        flash_base = cdp.eval("Math.round(scrollY)") or 0
+        if flash_base > 120:
+            cdp.eval("window.__scrollFlash = []; window.__scrollFlashOn = true; addEventListener('scroll', () => { if (window.__scrollFlashOn) window.__scrollFlash.push(Math.round(scrollY)); })")
+            cdp.eval("document.querySelector('#settingsBtn')?.click()")
+            wait_for(cdp, "document.querySelector('#settings')?.classList.contains('show')", "flash check settings open")
+            cdp.eval("history.back()")
+            wait_for(cdp, "!document.querySelector('#settings')?.classList.contains('show')", "flash check settings closed")
+            settle(cdp, 450)
+            cdp.eval("window.__scrollFlashOn = false")
+            flash_log = cdp.eval("window.__scrollFlash || []") or []
+            flash_now = cdp.eval("Math.round(scrollY)") or 0
+            if any(v < flash_base - 90 for v in flash_log):
+                raise CheckFailed(f"Closing the settings layer scrolled the list (flash to top): base={flash_base}, log={flash_log}")
+            if abs(flash_now - flash_base) > 5:
+                raise CheckFailed(f"Scroll position drifted after closing the settings layer: base={flash_base}, now={flash_now}, log={flash_log}")
+
         # Settings -> NSFW confirmation is a nested pair of returnable layers.
         cdp.eval("document.querySelector('#settingsBtn')?.click()")
         wait_for(cdp, "document.querySelector('#settings')?.classList.contains('show')", "settings layer")


### PR DESCRIPTION
## 改动

- 直接关闭子浮层时只收敛浮层，不再重放列表路由或恢复滚动位置
- 所有主要焦点回还使用 `focus({ preventScroll: true })`，避免隐藏顶栏按钮触发浏览器滚动
- 增加历史管理单测和真实浏览器滚动回归断言

## 根因

关闭浮层的 `popstate` 原本无条件调用路由恢复，列表先被 `resetScroll` 滚到顶部，随后延迟恢复原位置；面板关闭后的焦点回还还可能触发浏览器将隐藏顶栏滚入视口，两者叠加造成明显闪屏。

## 验证

- `node tools/test_browser_history.mjs`
- `node tools/test_favorites_backup.mjs`
- `python tools/check_cache_buster.py`
- `python -m py_compile tools/verify_ui.py tools/preview_server.py`
- `python tools/verify_ui.py --base-url http://localhost:8767/ --only "mobile atlas back stack"`
- 完整 UI 回归 14/14 PASS