### PR TITLE
个人屏蔽与控件统一

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -899,7 +899,7 @@ setBlockingUiActions({ refresh: () => {
   if (state.lightbox?.entry && isContentBlocked(state.lightbox.entry)) {
     closeLightbox({ historyMode: 'replace', immediate: true });
   }
-  applyFilter();
+  applyFilter({ transition: 'blocking' });
   if ($('#historyPanel') && !$('#historyPanel').hidden) renderHistoryPanel();
 } });
 

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -20,7 +20,7 @@ import { captureAtlasRoute, configureAtlasHistory, hasActiveSearchRoute, initial
 import { normalizeRoutePath, normalizeCodexRoutePath } from './app/codex-route-compat.js';
 import { pathFromCode } from './app/path-code.js';
 import { setupCodexPicker, setupAbout, setupTreeSpy, updateCodexPickerState, renderTree, renderCodexHeader, renderCategoryRail, updateRailActive, updateResultBar, updateEmptyState, setCodexUiActions } from './app/codex-ui.js';
-import { normalizeRecentEntries, normalizeLastBrowse, restoreBrowseScroll, scheduleBrowseStateSave, suppressBrowseStateSave, setHistoryActions } from './app/history.js';
+import { normalizeRecentEntries, normalizeLastBrowse, restoreBrowseScroll, scheduleBrowseStateSave, suppressBrowseStateSave, setHistoryActions, renderHistoryPanel } from './app/history.js';
 import { bindUI, applyDensity, setUiActions, updateSearchScopeControl } from './app/ui.js';
 import { setUpdatesActions } from './app/updates.js';
 import { maybeShowOnboarding } from './app/onboarding.js';
@@ -28,6 +28,8 @@ import { startIntro, beginIntroReveal, markIntroDataReady, introSettled } from '
 import { setupResumePrompt } from './app/resume-prompt.js';
 import { isHistoryRestoreToken } from './app/browser-history.js';
 import { setupTagRelay } from './app/tag-relay.js';
+import { loadContentBlocking, isContentBlocked } from './app/content-blocking.js';
+import { setupContentBlocking, hideCard, setBlockingUiActions, updateBlockingSummary } from './app/content-blocking-ui.js';
 
 let codexLoadSeq = 0;
 let favoritesBackupBound = false;
@@ -214,6 +216,7 @@ export async function init() {
     setupAbout();
     setupTreeSpy();
     bindUI();
+    setupContentBlocking();
     bindFavoritesBackup();
     state.pendingUrlState = readUrlState();
     const wantsFavorites = state.pendingUrlState.favorites || state.pendingUrlState.codex === FAVORITES_CODEX_ID;
@@ -679,7 +682,9 @@ export function applyFilter(options = {}) {
   const updateFilter = codexUpdateFilters(state.codex).find(filter => filter.id === state.updateFilter);
   if (updateFilter) list = list.filter(entry => entryMatchesUpdateFilter(entry, updateFilter));
   if (state.favoritesView) list = list.filter(isFav);   // 收藏视图里取消收藏即时消卡
-  state.list = rankSearchResults(list, plan);
+  const unblocked = list.filter(entry => !isContentBlocked(entry));
+  const blockedCount = list.length - unblocked.length;
+  state.list = rankSearchResults(unblocked, plan);
   const relatedDirectories = !plan.hasErrors && plan.positiveTerms.length
     ? findRelatedDirectories({
       codex: state.codex,
@@ -694,6 +699,7 @@ export function applyFilter(options = {}) {
   renderSearchExperience(plan, directoryOptions);
   updateResultBar();
   renderList(options);
+  updateBlockingSummary(blockedCount);
 }
 
 /* 收藏视图内取消收藏后：从仍被收藏的词条重算合成法典的条目/计数/目录树，刷新顶栏、横幅进度、
@@ -866,6 +872,7 @@ setMasonryActions({
   openLightbox,
   copyEntry,
   toggleFav,
+  hideCard,
   reportEntry: (entry, opts = {}) => openReportDialog({ entry, ...opts }),
 });
 
@@ -888,4 +895,13 @@ setUpdatesActions({
   },
 });
 
+setBlockingUiActions({ refresh: () => {
+  if (state.lightbox?.entry && isContentBlocked(state.lightbox.entry)) {
+    closeLightbox({ historyMode: 'replace', immediate: true });
+  }
+  applyFilter();
+  if ($('#historyPanel') && !$('#historyPanel').hidden) renderHistoryPanel();
+} });
+
+loadContentBlocking();
 init();

--- a/site/assets/app/MODULE_MAP.md
+++ b/site/assets/app/MODULE_MAP.md
@@ -30,7 +30,7 @@
 | `access.js` | 法典级与词条级 NSFW / R18G 判定、锁定提示 | — | `state.js`、`feedback.js` | 所有内容分级入口的单一判断层；调用方不得自行拼另一套门控 |
 | `content-blocking-core.js` | 个人屏蔽清单规范化、字面整词/短语匹配、正向字段投影 | — | — | 负面、目录、备注不参与；逐图 rawTag 按现有正向契约读取 |
 | `content-blocking.js` | 本地屏蔽清单、稳定身份匹配、缓存与跨标签页同步 | 独立 localStorage、关键词匹配 WeakMap、变更订阅 | `state.js`、`data.js`、`favorites-backup-core.js`、`content-blocking-core.js` | 复用身份兼容，独立于收藏状态；保存成功才提交内存；编辑后失效词条缓存 |
-| `content-blocking-ui.js` | 屏蔽管理、卡片隐藏/撤销、结果提示与主动打开时临时查看 | 页签、分页、结果命中数 | `state.js`、`utils.js`、`feedback.js`、`access.js`、`data.js`、`modal.js`、`content-blocking.js` | 注入刷新动作；调用方先执行分级门控；临时查看不修改持久清单 |
+| `content-blocking-ui.js` | 屏蔽管理、卡片隐藏/撤销、结果提示与主动打开时临时查看 | 页签、分页、结果命中数、按键复用的行节点与退场/高度动效 | `state.js`、`utils.js`、`feedback.js`、`access.js`、`data.js`、`modal.js`、`ui-motion.js`、`content-blocking.js` | 保存与刷新不等待动画；关闭/快切结清局部动效，移除项立即 inert；调用方先执行分级门控；临时查看不修改持久清单 |
 | `media.js` | 图片能力判断、资源路径、版本参数、缩略图与原图 URL | — | `state.js` | 只解决资源定位，不判断“用户是否有权看原图” |
 | `nai-sd.js` | `naiToSd`、`fmtSdWeight`、`formatCopyText` | — | — | 无 DOM 的格式转换层，主站和共创广场可复用 |
 | `sd-mode.js` | SD 模式的 localStorage 读写契约 | — | — | 共创广场通过同一存储契约同步，不导入主站 `state` |
@@ -67,7 +67,7 @@
 | 模块 | 职责 / 主要出口 | 模块状态 | 直接依赖 | 注入 / 边界 |
 | --- | --- | --- | --- | --- |
 | `codex-ui.js` | 法典选择器、目录树、横幅、分类轨、结果 / 空态、随机浏览与归档 UI；`exampleModel` 覆盖书卡 / 横幅的原图状态签；`codexCoverStyle` 共用封面位置与缩放 | 动作注入、访问视图缓存、目录监听、分支动效、提示 / 面板状态 | `state.js`、`utils.js`、`access.js`、`data.js`、`media.js`、`feedback.js`、`browser-history.js`、`modal.js`、`ui-motion.js` | 注入 `loadCodex`、`applySearch`、`applyFilter`、`openLightbox`、`syncUrlState`、`updateVirtualCards`；编辑器可追加 `decorateDoor` |
-| `masonry.js` | 虚拟瀑布流、卡片、图片加载、测高、重排与入场动效 | 动作注入、布局缓存、虚拟窗口、重排与动效状态 | `state.js`、`utils.js`、`feedback.js`、`search.js`、`media.js`、`copy.js`、`favorites.js`、`codex-ui.js` | 注入 `openLightbox`、`copyEntry`、`toggleFav`、`reportEntry`、`hideCard`；不静态导入 `lightbox.js` 或 `report.js` |
+| `masonry.js` | 虚拟瀑布流、卡片、图片加载、测高、重排与入场动效；屏蔽成员变更的节点复用 | 动作注入、布局缓存、虚拟窗口、重排、限时退场残影与动效状态 | `state.js`、`utils.js`、`feedback.js`、`search.js`、`media.js`、`copy.js`、`favorites.js`、`codex-ui.js`、`ui-motion.js` | 屏蔽保存后复用剩余节点/图片/同宽实测高度；退场不持有业务状态且立即 inert，清空/重排结清；注入 `openLightbox`、`copyEntry`、`toggleFav`、`reportEntry`、`hideCard`；不静态导入 `lightbox.js` 或 `report.js` |
 | `lightbox.js` | 灯箱开关、跨词条步进、预载、原图 / 分享 / 收藏 / 反馈与 FLIP 辅助 | 当前序号、关闭计时、焦点与缩略图身份、预载缓存 | `state.js`、`utils.js`、`masonry.js`、`search.js`、`copy.js`、`nai-sd.js`、`history.js`、`router.js`、`data.js`、`media.js`、`original-capability.js`、`access.js`、`report.js`、`browser-history.js`、`favorites.js`、`modal.js`、`content-blocking.js`、`content-blocking-ui.js` | 原图提示按真实来源的 `exampleModel` 标明模型；背景关闭复用手势门并保留滑图后的 click 抑制；灯箱动效维护方式见本地私有文档 `docs/经验/前端灯箱FLIP动效.md` |
 | `report.js` | 反馈提交、上下文打包、公开进度列表和兜底复制 | 当前提交上下文、触发点、公开列表 / 筛选状态与页签动效 | `state.js`、`utils.js`、`feedback.js`、`modal.js`、`media.js`、`original-capability.js`、`feedback-progress.js`、`local-ownership.js`、`clipboard.js`、`clipboard-fallback.js`、`ui-motion.js` | 拥有反馈业务；由瀑布流动作注入调用，不反向依赖瀑布流 |
 | `announcements.js` | 动态面板：公告 / 更新 / 反馈三页签切换、公告加载与未读角标 | 公告数据、加载状态与在途 Promise、当前页签与切换动效 | `ui-motion.js`、`utils.js`、`modal.js`、`history.js`、`updates.js`、`../data-source.js` | 数据读取走统一数据源，不自行拼发布路径；只把当前打开的那一栏标记为已读，未翻到的栏保留红点 |

--- a/site/assets/app/MODULE_MAP.md
+++ b/site/assets/app/MODULE_MAP.md
@@ -21,13 +21,16 @@
 
 | 模块 | 职责 / 主要出口 | 模块状态 | 直接依赖 | 注入 / 边界 |
 | --- | --- | --- | --- | --- |
-| `../app.js` | 主站组合根；`init`、`loadCodex`、`openRelatedDirectory`、收藏 / 全站搜索视图、筛选与搜索编排 | 法典加载序号、收藏备份绑定标记、目录选项缓存 | `state.js`、`utils.js`、`feedback.js`、`access.js`、`data.js`、`search.js`、`search-directories.js`、`search-ui.js`、`media.js`、`favorites.js`、`favorites-backup-core.js`、`favorites-backup.js`、`fav-codex.js`、`site-search.js`、`masonry.js`、`lightbox.js`、`copy.js`、`report.js`、`router.js`、`codex-route-compat.js`、`path-code.js`、`codex-ui.js`、`history.js`、`ui.js`、`onboarding.js`、`intro.js`、`resume-prompt.js`、`browser-history.js`、`tag-relay.js` | 把 `q + f` 编译为统一搜索计划，先做权限过滤再统计结果 / 目录；全部 `set*Actions(...)` 先于 `init()`，本地编辑器满足探测条件后才动态导入 `edit.js` |
+| `../app.js` | 主站组合根；`init`、`loadCodex`、`openRelatedDirectory`、收藏 / 全站搜索视图、筛选与搜索编排 | 法典加载序号、收藏备份绑定标记、目录选项缓存 | `state.js`、`utils.js`、`feedback.js`、`access.js`、`data.js`、`search.js`、`search-directories.js`、`search-ui.js`、`media.js`、`favorites.js`、`favorites-backup-core.js`、`favorites-backup.js`、`fav-codex.js`、`site-search.js`、`masonry.js`、`lightbox.js`、`copy.js`、`report.js`、`router.js`、`codex-route-compat.js`、`path-code.js`、`codex-ui.js`、`history.js`、`ui.js`、`onboarding.js`、`intro.js`、`resume-prompt.js`、`browser-history.js`、`tag-relay.js`、`content-blocking.js`、`content-blocking-ui.js` | 把 `q + f` 编译为统一搜索计划，先做权限过滤再统计结果 / 目录；全部 `set*Actions(...)` 先于 `init()`，本地编辑器满足探测条件后才动态导入 `edit.js` |
 | `../data-source.js` | 选择并读取 R2、同源代理或本地数据；`initializeDataSource`、`fetchDataJson*`、`getDataSource` | 初始化 Promise、当前数据源与 release 上下文 | — | 主站与共创广场共享；同一批引导数据必须来自同一 release，失败时整批切换来源 |
 | `state.js` | 全局运行态、存储键、密度和搜索范围规范化 | 共享 `state` 对象，含规范搜索草稿 / 筛选 / 语法问题 / 计划、相关目录及总数 | — | 只放跨模块运行态；模块私有状态留在所属模块 |
 | `utils.js` | DOM 查询、转义、安全 URL、路径比较、动效偏好、滚动与数值工具 | — | — | 无业务状态的通用工具层 |
 | `path-code.js` | `encodePathCode`、`pathFromCode`；目录路径与地址栏短码互转 | — | — | 编码是纯函数；解码需要法典树，分类改名后旧短码回退到可解析位置 |
 | `codex-route-compat.js` | `normalizeRoutePath`、`normalizeCodexRoutePath`；并册、改名、迁移后的旧路径兼容 | — | — | 保留只读迁移表；加载、历史恢复与最近浏览共用同一归一逻辑 |
 | `access.js` | 法典级与词条级 NSFW / R18G 判定、锁定提示 | — | `state.js`、`feedback.js` | 所有内容分级入口的单一判断层；调用方不得自行拼另一套门控 |
+| `content-blocking-core.js` | 个人屏蔽清单规范化、字面整词/短语匹配、正向字段投影 | — | — | 负面、目录、备注不参与；逐图 rawTag 按现有正向契约读取 |
+| `content-blocking.js` | 本地屏蔽清单、稳定身份匹配、缓存与跨标签页同步 | 独立 localStorage、关键词匹配 WeakMap、变更订阅 | `state.js`、`data.js`、`favorites-backup-core.js`、`content-blocking-core.js` | 复用身份兼容，独立于收藏状态；保存成功才提交内存；编辑后失效词条缓存 |
+| `content-blocking-ui.js` | 屏蔽管理、卡片隐藏/撤销、结果提示与主动打开时临时查看 | 页签、分页、结果命中数 | `state.js`、`utils.js`、`feedback.js`、`access.js`、`data.js`、`modal.js`、`content-blocking.js` | 注入刷新动作；调用方先执行分级门控；临时查看不修改持久清单 |
 | `media.js` | 图片能力判断、资源路径、版本参数、缩略图与原图 URL | — | `state.js` | 只解决资源定位，不判断“用户是否有权看原图” |
 | `nai-sd.js` | `naiToSd`、`fmtSdWeight`、`formatCopyText` | — | — | 无 DOM 的格式转换层，主站和共创广场可复用 |
 | `sd-mode.js` | SD 模式的 localStorage 读写契约 | — | — | 共创广场通过同一存储契约同步，不导入主站 `state` |
@@ -57,15 +60,15 @@
 | `favorites-backup.js` | 收藏导入导出面板、同页 / 跨页变更通知与旧域迁移入口 | 对话框状态、法典索引 Promise | `modal.js`、`browser-history.js`、`favorites-backup-core.js`、`favorites-origin-migration.js`、`../data-source.js`、`favorites-transfer.js`、`clipboard.js`、`clipboard-fallback.js` | 页面提供法典索引；只广播受影响 scope，各页面自行重读内存收藏 |
 | `fav-codex.js` | 构建“全部收藏”虚拟法典 | — | `state.js`、`data.js`、`access.js`、`media.js`、`favorites-backup-core.js` | 不写入 `state.codexes`；给条目补 `_src*`，并暴露各真实来源的 `_sourceDirectoryTrees` 供目录排序 |
 | `site-search.js` | 构建并失效“全站搜索”虚拟法典 | 成功结果缓存、在途 Promise、失效代次 | `state.js`、`data.js`、`access.js`、`media.js` | 只缓存完整成功且非降级的结果；编辑后显式失效；条目携带 `_src*`，并按来源顺序暴露 `_sourceDirectoryTrees` |
-| `history.js` | 最近复制、浏览快照、恢复、打开历史条目与滚动复位 | `historyActions`、保存计时 / 抑制状态、恢复代次 | `state.js`、`utils.js`、`media.js`、`router.js`、`codex-route-compat.js`、`access.js`、`feedback.js`、`data.js`、`fav-codex.js`、`site-search.js`、`browser-history.js` | 注入 `loadCodex`、两个虚拟视图入口、`openEntryDeepLink`、`renderTree`、`applyFilter`、`updateVirtualCards`；不得反向导入 `copy.js` |
+| `history.js` | 最近复制、浏览快照、恢复、打开历史条目与滚动复位 | `historyActions`、保存计时 / 抑制状态、恢复代次；最近记录屏蔽核验的法典缓存 | `state.js`、`utils.js`、`media.js`、`router.js`、`codex-route-compat.js`、`access.js`、`feedback.js`、`data.js`、`fav-codex.js`、`site-search.js`、`browser-history.js`、`content-blocking.js`、`favorites-backup-core.js` | 注入 `loadCodex`、两个虚拟视图入口、`openEntryDeepLink`、`renderTree`、`applyFilter`、`updateVirtualCards`；不得反向导入 `copy.js` |
 
 ## 页面与交互表面
 
 | 模块 | 职责 / 主要出口 | 模块状态 | 直接依赖 | 注入 / 边界 |
 | --- | --- | --- | --- | --- |
 | `codex-ui.js` | 法典选择器、目录树、横幅、分类轨、结果 / 空态、随机浏览与归档 UI；`exampleModel` 覆盖书卡 / 横幅的原图状态签；`codexCoverStyle` 共用封面位置与缩放 | 动作注入、访问视图缓存、目录监听、分支动效、提示 / 面板状态 | `state.js`、`utils.js`、`access.js`、`data.js`、`media.js`、`feedback.js`、`browser-history.js`、`modal.js`、`ui-motion.js` | 注入 `loadCodex`、`applySearch`、`applyFilter`、`openLightbox`、`syncUrlState`、`updateVirtualCards`；编辑器可追加 `decorateDoor` |
-| `masonry.js` | 虚拟瀑布流、卡片、图片加载、测高、重排与入场动效 | 动作注入、布局缓存、虚拟窗口、重排与动效状态 | `state.js`、`utils.js`、`feedback.js`、`search.js`、`media.js`、`copy.js`、`favorites.js`、`codex-ui.js` | 注入 `openLightbox`、`copyEntry`、`toggleFav`、`reportEntry`；不静态导入 `lightbox.js` 或 `report.js` |
-| `lightbox.js` | 灯箱开关、跨词条步进、预载、原图 / 分享 / 收藏 / 反馈与 FLIP 辅助 | 当前序号、关闭计时、焦点与缩略图身份、预载缓存 | `state.js`、`utils.js`、`masonry.js`、`search.js`、`copy.js`、`nai-sd.js`、`history.js`、`router.js`、`data.js`、`media.js`、`original-capability.js`、`access.js`、`report.js`、`browser-history.js`、`favorites.js`、`modal.js` | 原图提示按真实来源的 `exampleModel` 标明模型；背景关闭复用手势门并保留滑图后的 click 抑制；灯箱动效维护方式见本地私有文档 `docs/经验/前端灯箱FLIP动效.md` |
+| `masonry.js` | 虚拟瀑布流、卡片、图片加载、测高、重排与入场动效 | 动作注入、布局缓存、虚拟窗口、重排与动效状态 | `state.js`、`utils.js`、`feedback.js`、`search.js`、`media.js`、`copy.js`、`favorites.js`、`codex-ui.js` | 注入 `openLightbox`、`copyEntry`、`toggleFav`、`reportEntry`、`hideCard`；不静态导入 `lightbox.js` 或 `report.js` |
+| `lightbox.js` | 灯箱开关、跨词条步进、预载、原图 / 分享 / 收藏 / 反馈与 FLIP 辅助 | 当前序号、关闭计时、焦点与缩略图身份、预载缓存 | `state.js`、`utils.js`、`masonry.js`、`search.js`、`copy.js`、`nai-sd.js`、`history.js`、`router.js`、`data.js`、`media.js`、`original-capability.js`、`access.js`、`report.js`、`browser-history.js`、`favorites.js`、`modal.js`、`content-blocking.js`、`content-blocking-ui.js` | 原图提示按真实来源的 `exampleModel` 标明模型；背景关闭复用手势门并保留滑图后的 click 抑制；灯箱动效维护方式见本地私有文档 `docs/经验/前端灯箱FLIP动效.md` |
 | `report.js` | 反馈提交、上下文打包、公开进度列表和兜底复制 | 当前提交上下文、触发点、公开列表 / 筛选状态与页签动效 | `state.js`、`utils.js`、`feedback.js`、`modal.js`、`media.js`、`original-capability.js`、`feedback-progress.js`、`local-ownership.js`、`clipboard.js`、`clipboard-fallback.js`、`ui-motion.js` | 拥有反馈业务；由瀑布流动作注入调用，不反向依赖瀑布流 |
 | `announcements.js` | 动态面板：公告 / 更新 / 反馈三页签切换、公告加载与未读角标 | 公告数据、加载状态与在途 Promise、当前页签与切换动效 | `ui-motion.js`、`utils.js`、`modal.js`、`history.js`、`updates.js`、`../data-source.js` | 数据读取走统一数据源，不自行拼发布路径；只把当前打开的那一栏标记为已读，未翻到的栏保留红点 |
 | `updates.js` | 跨书更新时间线：`loadUpdates`、`updatesDigest`、面板列表与顶栏气泡渲染、已读标记、行点击派发 | 批次数据、加载状态与在途 Promise；已读集合存 `localStorage` | `utils.js`、`data.js`、`codex-ui.js`、`../data-source.js` | 注入 `openBatch`（`app.js` 提供：换书 + 落到该批次筛选）。条数口径必须与 `data.js` 的 `updateFilterDefinitions` / `entryMatchesUpdateFilter` 以及 `tools/build_updates_index.py` 三处一致；行点击的 `consumeLayer` 由调用方声明，本模块不推断 |
@@ -95,7 +98,7 @@
 
 | 模块 | 职责 / 主要出口 | 模块状态 | 直接依赖 | 注入 / 边界 |
 | --- | --- | --- | --- | --- |
-| `edit.js` | `initEditMode`；本地词条、目录、法典与图片编辑 UI | 服务端能力、注入动作、启用 / 保存 / 弹层与当前词条状态 | `state.js`、`utils.js`、`feedback.js`、`lightbox.js`、`codex-ui.js`、`modal.js`、`../data-source.js`、`search.js`、`search-directories.js`、`masonry.js`、`site-search.js`、`edit-core.js` | `app.js` 探测同源 `/__edit__/ping` 成功后才动态导入；原地编辑后同时失效词条文本、目录和全站搜索缓存；线上不得静态加载 |
+| `edit.js` | `initEditMode`；本地词条、目录、法典与图片编辑 UI | 服务端能力、注入动作、启用 / 保存 / 弹层与当前词条状态 | `state.js`、`utils.js`、`feedback.js`、`lightbox.js`、`codex-ui.js`、`modal.js`、`../data-source.js`、`search.js`、`search-directories.js`、`masonry.js`、`site-search.js`、`edit-core.js`、`content-blocking.js` | `app.js` 探测同源 `/__edit__/ping` 成功后才动态导入；原地编辑后同时失效词条文本、目录和全站搜索缓存；线上不得静态加载 |
 | `edit-core.js` | 路径编解码、目录列表、搜索结果还原、图片名标题、角色提示归一、字段 diff / 校验 / 合并 | — | — | 无 DOM 的纯函数，供 `edit.js` 与 Node 测试复用；维护方式见本地私有文档 `docs/经验/本地嵌入式编辑器.md` |
 
 ## 必须保持的接线约束
@@ -104,6 +107,7 @@
 - `router.js`、`history.js`、`codex-ui.js` 通过注入调用瀑布流，避免反向静态依赖；`masonry.js` 同理通过动作注入打开灯箱和反馈。
 - `browser-history.js` 必须保持页面无关。历史层的底层 open / close handler 不得自己改 history；用户动作包装器才决定 push、replace 或 back。完整套路见本地私有文档 `docs/经验/浏览器历史状态管理.md`。
 - 内容分级统一经过 `access.js`；快照、历史或虚拟视图无法证明可访问时，保持 fail-closed。
+- 个人屏蔽独立于内容分级：`app.js` 过滤最终结果，卡片由动作注入执行隐藏，灯箱在分级判定后拦截并提供临时查看；`app.js` 初始化管理入口，`ui.js` 把面板纳入快捷键遮挡。最近记录在关键词启用时先加载真实词条核验，再渲染缩略图；`edit.js` 失效匹配缓存。清单仅覆盖主图鉴，收藏关系、共创广场和中转站编排状态仍各自管理。
 - 收藏和全站搜索是临时虚拟法典，不进入 `state.codexes`；跨法典消费者必须用 `_src*` 回到真实来源。
 - 普通搜索默认只召回标题、标签和角色正向提示词；隐藏字段必须由显式筛选访问，路径文字不得把目录内容混入图片结果。
 - 搜索地址把正向输入留在 `q`、规范筛选放进重复 `f`；相关目录和精确目录筛选都必须在权限过滤后基于真实来源树生成。

--- a/site/assets/app/announcements.js
+++ b/site/assets/app/announcements.js
@@ -115,7 +115,7 @@ export function selectAnnouncementsTab(value) {
   const direction = TABS.indexOf(tab) > TABS.indexOf(activeTab) ? 1 : -1;
   finishTabMotion?.();
   activeTab = tab;
-  mask?.querySelector('.announcements-tabs')?.style.setProperty('--ann-tab-index', String(TABS.indexOf(tab)));
+  mask?.querySelector('.announcements-tabs')?.style.setProperty('--seg-index', String(TABS.indexOf(tab)));
   document.querySelectorAll('[data-announcements-tab]').forEach(button => {
     const active = button.dataset.announcementsTab === tab;
     button.setAttribute('aria-selected', active ? 'true' : 'false');

--- a/site/assets/app/clipboard-fallback.js
+++ b/site/assets/app/clipboard-fallback.js
@@ -41,8 +41,8 @@ function ensureClipboardFallback() {
       <footer class="favorites-backup-footer clipboard-fallback-footer">
         <span class="favorites-backup-status" aria-live="polite">文本已全选</span>
         <div class="clipboard-fallback-actions">
-          <button class="favorites-backup-secondary" type="button" data-clipboard-select>重新选择全部</button>
-          <button class="favorites-backup-primary" type="button" data-clipboard-close>关闭</button>
+          <button class="panel-action favorites-backup-secondary" type="button" data-clipboard-select>重新选择全部</button>
+          <button class="panel-action is-primary favorites-backup-primary" type="button" data-clipboard-close>关闭</button>
         </div>
       </footer>
     </section>`;

--- a/site/assets/app/codex-ui.js
+++ b/site/assets/app/codex-ui.js
@@ -1112,7 +1112,7 @@ function updateFilterControls() {
   for (const filter of filters) {
     const btn = document.createElement('button');
     btn.type = 'button';
-    btn.className = `update-filter-btn${filter.latest ? ' is-latest' : ''}`;
+    btn.className = `bar-btn update-filter-btn${filter.latest ? ' is-latest' : ''}`;
     btn.dataset.updateFilter = filter.id;
     btn.setAttribute('aria-pressed', state.updateFilter === filter.id ? 'true' : 'false');
     if (filter.latest) {

--- a/site/assets/app/content-blocking-core.js
+++ b/site/assets/app/content-blocking-core.js
@@ -1,0 +1,57 @@
+export const BLOCKING_STORAGE_KEY = 'fadian-content-blocking-v1';
+export const BLOCKING_WORD_LIMIT = 100;
+export const BLOCKING_ENTRY_LIMIT = 5000;
+
+export function normalizeBlockedWord(value) {
+  return String(value ?? '').normalize('NFKC').toLowerCase().replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+export function normalizeBlockingPreferences(value) {
+  const source = value && typeof value === 'object' && value.version === 1 ? value : {};
+  const words = Array.isArray(source.words) ? source.words : [];
+  const entries = Array.isArray(source.entries) ? source.entries : [];
+  const seen = new Set();
+  return {
+    version: 1,
+    enabled: source.enabled !== false,
+    words: [...new Set(words.filter(word => typeof word === 'string').map(normalizeBlockedWord)
+      .filter(word => word && word.length <= 80))].slice(0, BLOCKING_WORD_LIMIT),
+    entries: entries.filter(item => {
+      if (!item || typeof item.key !== 'string' || !item.key || item.key.length > 500 || seen.has(item.key)) return false;
+      seen.add(item.key);
+      return true;
+    }).slice(0, BLOCKING_ENTRY_LIMIT).map(item => ({
+      key: item.key,
+      codexId: String(item.codexId || '').slice(0, 200),
+      title: String(item.title || '未命名卡片').slice(0, 200),
+      codexTitle: String(item.codexTitle || '').slice(0, 200),
+      rating: String(item.rating || ''),
+      path: Array.isArray(item.path) ? item.path.map(String) : [],
+    })),
+  };
+}
+
+export function compileBlockedWords(words) {
+  return words.map(word => {
+    const normalized = normalizeBlockedWord(word);
+    const escaped = normalized.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // 英文整词匹配；中文按短语匹配。下划线与空格等价，权重符号保持为边界。
+    const start = /^[\p{Script=Latin}\p{N}]/u.test(normalized) ? '(^|[^\\p{Script=Latin}\\p{N}])' : '';
+    const end = /[\p{Script=Latin}\p{N}]$/u.test(normalized) ? '(?=$|[^\\p{Script=Latin}\\p{N}])' : '';
+    return { word: normalized, pattern: new RegExp(start + escaped + end, 'u') };
+  });
+}
+
+export function positiveBlockingFields(entry) {
+  const characters = items => (Array.isArray(items) ? items : []).map(item => item?.prompt || item?.positive || '');
+  const images = Array.isArray(entry?.images) ? entry.images : [];
+  // images[].rawTag 的数据契约是逐图正向 prompt；负面、备注和目录均不参与。
+  return [entry?.title, entry?.tags, ...characters(entry?.characterPrompts),
+    ...images.flatMap(item => typeof item === 'object'
+      ? [item.prompt, item.positive, item.tags, item.rawTag || item.rawTags, ...characters(item.characterPrompts)] : [])]
+    .filter(value => typeof value === 'string' && value.trim()).map(normalizeBlockedWord);
+}
+
+export function matchBlockedWord(fields, compiled) {
+  return compiled.find(({ pattern }) => fields.some(text => pattern.test(text)))?.word || '';
+}

--- a/site/assets/app/content-blocking-ui.js
+++ b/site/assets/app/content-blocking-ui.js
@@ -1,0 +1,182 @@
+import { state } from './state.js';
+import { $, esc } from './utils.js';
+import { toast } from './feedback.js';
+import { isEntryAccessBlocked, isCodexLocked } from './access.js';
+import { findCodexMeta } from './data.js';
+import { bindBackdropDismiss, openMask, closeMask, trapFocus, focusFirstIn } from './modal.js';
+import {
+  getBlockingPreferences, subscribeContentBlocking, receiveBlockingStorage, contentBlockReason,
+  hideContentEntry, restoreContentEntry, addBlockedWords, removeBlockedWord, setContentBlockingEnabled,
+} from './content-blocking.js';
+
+const actions = { refresh: () => {} };
+let currentTab = 'words';
+let shownEntries = 40;
+let renderedWords = new Set();   // 只给真正新增的屏蔽词加入场动画，整表重绘不闪
+let resultHiddenCount = 0;
+
+export function setBlockingUiActions(value) { Object.assign(actions, value); }
+
+function showSaveError(result) {
+  if (!result.error) return false;
+  toast(result.error, '!');
+  return true;
+}
+
+export function hideCard(entry) {
+  const result = hideContentEntry(entry);
+  if (showSaveError(result)) return;
+  toast(getBlockingPreferences().enabled ? '已隐藏卡片' : '已加入屏蔽清单，屏蔽已暂停', '✓', {
+    label: '撤销', onClick: () => {
+      if (!showSaveError(restoreContentEntry(result.key))) toast('已撤销隐藏');
+    },
+  });
+}
+
+export function openBlockingManager(trigger = document.activeElement) {
+  renderBlockingManager();
+  openMask($('#contentBlocking'), trigger);
+}
+
+export function updateBlockingSummary(hiddenCount = resultHiddenCount) {
+  resultHiddenCount = hiddenCount;
+  const prefs = getBlockingPreferences();
+  const count = prefs.words.length + prefs.entries.length;
+  const button = $('#blockingResultBtn');
+  if (button) {
+    button.textContent = count && !prefs.enabled ? '屏蔽已暂停' : (hiddenCount ? `已屏蔽 ${hiddenCount} 项` : '屏蔽管理');
+    button.classList.toggle('is-on', Boolean(count && prefs.enabled));
+  }
+  const summary = $('#blockingSettingsSummary');
+  if (summary) summary.textContent = count
+    ? `${prefs.words.length} 个词 · ${prefs.entries.length} 张卡片${prefs.enabled ? '' : ' · 已暂停'}`
+    : '屏蔽词与单独隐藏的卡片';
+  const empty = $('#empty');
+  if (empty && !state.list.length && hiddenCount && !state.searchPlan?.hasActiveSearch) {
+    empty.hidden = false;
+    empty.innerHTML = '<div class="empty-mark" aria-hidden="true">—</div><h2>当前结果已全部屏蔽</h2>'
+      + `<p>${hiddenCount} 项命中了屏蔽清单。</p><div class="empty-actions"><button type="button">管理屏蔽</button></div>`;
+    empty.querySelector('button').onclick = event => openBlockingManager(event.currentTarget);
+  }
+}
+
+function renderBlockingManager() {
+  const prefs = getBlockingPreferences();
+  const mask = $('#contentBlocking');
+  if (!mask) return;
+  $('#blockingEnabled').checked = prefs.enabled;
+  $('#blockingPaused').hidden = prefs.enabled;
+  $('#blockingWordsTab').textContent = `屏蔽词 ${prefs.words.length}`;
+  $('#blockingEntriesTab').textContent = `单独隐藏 ${prefs.entries.length}`;
+  mask.querySelector('.blocking-tabs')?.style.setProperty('--seg-index', currentTab === 'entries' ? '1' : '0');
+  for (const tab of mask.querySelectorAll('[data-blocking-tab]')) {
+    const active = tab.dataset.blockingTab === currentTab;
+    tab.setAttribute('aria-selected', String(active));
+    tab.tabIndex = active ? 0 : -1;
+  }
+  $('#blockingWordsPanel').hidden = currentTab !== 'words';
+  $('#blockingEntriesPanel').hidden = currentTab !== 'entries';
+  $('#blockingWordList').innerHTML = prefs.words.map(word => `<li${renderedWords.has(word) ? '' : ' class="is-new"'}><span>${esc(word)}</span><button type="button" data-remove-word="${esc(word)}" aria-label="取消屏蔽 ${esc(word)}">×</button></li>`).join('');
+  renderedWords = new Set(prefs.words);
+  $('#blockingWordsEmpty').hidden = Boolean(prefs.words.length);
+  $('#blockingEntryList').innerHTML = prefs.entries.slice(0, shownEntries).map(item => {
+    const locked = isCodexLocked(findCodexMeta(item.codexId)) || isEntryAccessBlocked({ ...item, _srcCodexId: item.codexId });
+    const title = locked ? '受限卡片' : item.title;
+    const source = locked ? '开启相应内容分级后可查看名称' : item.codexTitle;
+    return `<li><div><b>${esc(title)}</b><span>${esc(source)}</span></div><button type="button" class="panel-action is-sm" data-restore-entry="${esc(item.key)}" aria-label="恢复 ${esc(title)}">恢复</button></li>`;
+  }).join('');
+  $('#blockingEntriesEmpty').hidden = Boolean(prefs.entries.length);
+  $('#blockingMoreEntries').hidden = prefs.entries.length <= shownEntries;
+}
+
+export function promptBlockedEntry(entry, reveal) {
+  const reason = contentBlockReason(entry);
+  if (!reason) { reveal(); return; }
+  const mask = $('#blockingReveal');
+  if (!mask) return;
+  $('#blockingRevealReason').textContent = reason.type === 'word'
+    ? `命中屏蔽词「${reason.word}」。` : '这张卡片已在屏蔽清单中。';
+  const sourceId = entry._srcCodexId || state.codex?.id;
+  $('#blockingRevealOnce').onclick = () => {
+    if (sourceId !== (entry._srcCodexId || state.codex?.id)) { closeMask(mask); return; }
+    closeMask(mask, { historyMode: 'none' });
+    reveal();
+  };
+  openMask(mask);
+}
+
+export function setupContentBlocking() {
+  const mask = $('#contentBlocking');
+  if (!mask) return;
+  $('#blockingSettingsBtn').onclick = event => openBlockingManager(event.currentTarget);
+  $('#blockingResultBtn').onclick = event => openBlockingManager(event.currentTarget);
+  for (const [id, closeId] of [['contentBlocking', 'blockingClose'], ['blockingReveal', 'blockingRevealClose']]) {
+    const panel = $(`#${id}`);
+    $(`#${closeId}`).onclick = () => closeMask(panel);
+    bindBackdropDismiss(panel, () => closeMask(panel));
+    panel.addEventListener('keydown', event => {
+      if (event.key === 'Escape') { event.preventDefault(); event.stopPropagation(); closeMask(panel); }
+      else trapFocus(event, panel);
+    });
+  }
+  $('#blockingRevealCancel').onclick = () => closeMask($('#blockingReveal'));
+  // 拖选到遮罩外后焦点可能落回 body；仍由最上层窗口接住 Esc。
+  document.addEventListener('keydown', event => {
+    const top = ['contentBlocking', 'blockingReveal'].map(id => $(`#${id}`)).find(panel => panel.classList.contains('show'));
+    if (!top) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      closeMask(top);
+    } else if (event.key === 'Tab' && !top.contains(document.activeElement)) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      focusFirstIn(top);
+    }
+  }, true);
+  $('#blockingRevealManage').onclick = event => openBlockingManager(event.currentTarget);
+  $('#blockingEnabled').onchange = event => {
+    if (showSaveError(setContentBlockingEnabled(event.target.checked))) renderBlockingManager();
+  };
+  const chooseTab = tab => { currentTab = tab.dataset.blockingTab; renderBlockingManager(); tab.focus(); };
+  const tabs = [...mask.querySelectorAll('[data-blocking-tab]')];
+  tabs.forEach((tab, index) => {
+    tab.onclick = () => chooseTab(tab);
+    tab.onkeydown = event => {
+      if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+      event.preventDefault();
+      chooseTab(tabs[event.key === 'Home' ? 0 : event.key === 'End' ? tabs.length - 1 : (index + 1) % tabs.length]);
+    };
+  });
+  $('#blockingWordInput').oninput = event => {
+    $('#blockingWordError').hidden = true;
+    event.target.setAttribute('aria-invalid', 'false');
+  };
+  $('#blockingWordForm').onsubmit = event => {
+    event.preventDefault();
+    const input = $('#blockingWordInput');
+    const result = addBlockedWords(input.value);
+    const error = $('#blockingWordError');
+    error.textContent = result.error || '';
+    error.hidden = !result.error;
+    input.setAttribute('aria-invalid', String(Boolean(result.error)));
+    if (!result.error) input.value = '';
+    input.focus();
+  };
+  $('#blockingWordList').onclick = event => {
+    const button = event.target.closest('[data-remove-word]');
+    if (button && !showSaveError(removeBlockedWord(button.dataset.removeWord))) $('#blockingWordInput').focus();
+  };
+  $('#blockingEntryList').onclick = event => {
+    const button = event.target.closest('[data-restore-entry]');
+    if (button && !showSaveError(restoreContentEntry(button.dataset.restoreEntry))) {
+      ($('#blockingEntryList button') || $('#blockingEntriesTab')).focus();
+    }
+  };
+  $('#blockingMoreEntries').onclick = () => { shownEntries += 40; renderBlockingManager(); };
+  subscribeContentBlocking(() => { actions.refresh(); renderBlockingManager(); updateBlockingSummary(); });
+  window.addEventListener('storage', receiveBlockingStorage);
+  document.addEventListener('codex:loaded', renderBlockingManager);
+  renderBlockingManager();
+  updateBlockingSummary();
+}

--- a/site/assets/app/content-blocking-ui.js
+++ b/site/assets/app/content-blocking-ui.js
@@ -1,9 +1,10 @@
 import { state } from './state.js';
-import { $, esc } from './utils.js';
+import { $ } from './utils.js';
 import { toast } from './feedback.js';
 import { isEntryAccessBlocked, isCodexLocked } from './access.js';
 import { findCodexMeta } from './data.js';
 import { bindBackdropDismiss, openMask, closeMask, trapFocus, focusFirstIn } from './modal.js';
+import { animateUi, cancelUiMotion } from './ui-motion.js';
 import {
   getBlockingPreferences, subscribeContentBlocking, receiveBlockingStorage, contentBlockReason,
   hideContentEntry, restoreContentEntry, addBlockedWords, removeBlockedWord, setContentBlockingEnabled,
@@ -12,7 +13,9 @@ import {
 const actions = { refresh: () => {} };
 let currentTab = 'words';
 let shownEntries = 40;
-let renderedWords = new Set();   // 只给真正新增的屏蔽词加入场动画，整表重绘不闪
+const renderedLists = { words: new Map(), entries: new Map() };
+const exitingRows = new Map();
+let finishManagerMotion = null;
 let resultHiddenCount = 0;
 
 export function setBlockingUiActions(value) { Object.assign(actions, value); }
@@ -34,7 +37,8 @@ export function hideCard(entry) {
 }
 
 export function openBlockingManager(trigger = document.activeElement) {
-  renderBlockingManager();
+  settleManagerMotion();
+  renderBlockingManager({ motion: false });
   openMask($('#contentBlocking'), trigger);
 }
 
@@ -60,10 +64,136 @@ export function updateBlockingSummary(hiddenCount = resultHiddenCount) {
   }
 }
 
-function renderBlockingManager() {
+function settleManagerMotion() {
+  finishManagerMotion?.();
+  for (const finish of [...exitingRows.values()]) finish();
+  for (const records of Object.values(renderedLists)) {
+    for (const row of records.values()) cancelUiMotion(row);
+  }
+}
+
+function snapshotBlockingList(list, records, visible) {
+  if (!visible) return new Map();
+  const origin = list.getBoundingClientRect();
+  return new Map([...records.values()].map(row => {
+    const rect = row.getBoundingClientRect();
+    return [row, {
+      left: rect.left - origin.left, top: rect.top - origin.top,
+      width: rect.width, height: rect.height, opacity: Number(getComputedStyle(row).opacity),
+    }];
+  }));
+}
+
+function leaveBlockingRow(row, snapshot) {
+  row.inert = true;
+  row.setAttribute('aria-hidden', 'true');
+  row.dataset.blockingExit = '';
+  const button = row.querySelector('button');
+  button.disabled = true;
+  button.tabIndex = -1;
+  delete button.dataset.removeWord;
+  delete button.dataset.restoreEntry;
+  if (!snapshot?.width || !snapshot.height) { row.remove(); return; }
+  // 残影留在清单内离流；业务与焦点立即前进，不再保留能误触的删除入口。
+  Object.assign(row.style, {
+    position: 'absolute', left: `${snapshot.left}px`, top: `${snapshot.top}px`,
+    width: `${snapshot.width}px`, height: `${snapshot.height}px`, maxWidth: 'none',
+    margin: '0', boxSizing: 'border-box', pointerEvents: 'none',
+  });
+  row.parentElement.append(row);
+  const animation = animateUi(row, [
+    { opacity: snapshot.opacity, translate: '0 0', scale: '1' },
+    { opacity: 0, translate: '0 -4px', scale: '.97' },
+  ], { duration: 160 });
+  if (!animation) { row.remove(); return; }
+  let timer;
+  const finish = () => {
+    if (exitingRows.get(row) !== finish) return;
+    exitingRows.delete(row);
+    clearTimeout(timer);
+    cancelUiMotion(row);
+    row.remove();
+  };
+  exitingRows.set(row, finish);
+  timer = setTimeout(finish, 240);
+  animation.finished.then(finish, finish);
+}
+
+function reconcileBlockingList(kind, list, items, snapshots, visible, motions) {
+  const previous = renderedLists[kind];
+  const next = new Map();
+  for (const item of items) {
+    const key = kind === 'words' ? item : item.key;
+    let row = previous.get(key);
+    if (!row) {
+      row = document.createElement('li');
+      row.innerHTML = kind === 'words' ? '<span></span><button type="button">×</button>'
+        : '<div><b></b><span></span></div><button type="button" class="panel-action is-sm">恢复</button>';
+    }
+    const button = row.querySelector('button');
+    if (kind === 'words') {
+      row.querySelector('span').textContent = item;
+      button.dataset.removeWord = item;
+      button.setAttribute('aria-label', `取消屏蔽 ${item}`);
+    } else {
+      const locked = isCodexLocked(findCodexMeta(item.codexId)) || isEntryAccessBlocked({ ...item, _srcCodexId: item.codexId });
+      const title = locked ? '受限卡片' : item.title;
+      row.querySelector('b').textContent = title;
+      row.querySelector('span').textContent = locked ? '开启相应内容分级后可查看名称' : item.codexTitle;
+      button.dataset.restoreEntry = item.key;
+      button.setAttribute('aria-label', `恢复 ${title}`);
+    }
+    next.set(key, row);
+  }
+  for (const [key, row] of previous) {
+    if (!next.has(key)) leaveBlockingRow(row, snapshots.get(row));
+  }
+  const rows = [...next.values()];
+  rows.forEach((row, index) => {
+    if (list.children[index] !== row) list.insertBefore(row, list.children[index] || null);
+    row.classList.toggle('is-last', index === rows.length - 1);
+  });
+  renderedLists[kind] = next;
+  if (!visible) return;
+  const origin = list.getBoundingClientRect();
+  const positions = rows.map(row => row.getBoundingClientRect());
+  rows.forEach((row, index) => {
+    const before = snapshots.get(row);
+    const x = before ? before.left - (positions[index].left - origin.left) : 0;
+    const y = before ? before.top - (positions[index].top - origin.top) : 4;
+    if (!before || Math.abs(x) > .5 || Math.abs(y) > .5 || before.opacity < .99) {
+      const animation = animateUi(row, [
+        { opacity: before?.opacity ?? 0, translate: `${x}px ${y}px` },
+        { opacity: 1, translate: '0 0' },
+      ]);
+      if (animation) motions.set(row, animation);
+    }
+  });
+}
+
+function renderBlockingManager({ tab = currentTab, motion = true } = {}) {
   const prefs = getBlockingPreferences();
   const mask = $('#contentBlocking');
   if (!mask) return;
+  const shell = mask.querySelector('.blocking-views');
+  const views = { words: $('#blockingWordsPanel'), entries: $('#blockingEntriesPanel') };
+  const lists = { words: $('#blockingWordList'), entries: $('#blockingEntryList') };
+  const moving = Boolean(motion && !mask.hidden && mask.classList.contains('show'));
+  const previousTab = currentTab;
+  const previousView = views[previousTab];
+  const oldHeight = moving ? shell.getBoundingClientRect().height : 0;
+  const oldOpacity = moving ? getComputedStyle(previousView).opacity : '1';
+  const oldTranslate = moving ? getComputedStyle(previousView).translate : 'none';
+  const snapshots = Object.fromEntries(Object.entries(lists).map(([kind, list]) => [kind,
+    snapshotBlockingList(list, renderedLists[kind], moving && kind === previousTab && tab === previousTab),
+  ]));
+  const focused = document.activeElement;
+  const focusedRows = [...renderedLists[previousTab].values()];
+  const focusedIndex = focusedRows.findIndex(row => row.contains(focused));
+  // 快速操作先取画面中的位置与高度，再结清旧轮；迟到回调不能收起新的当前页。
+  settleManagerMotion();
+  currentTab = tab;
+  const motions = new Map();
   $('#blockingEnabled').checked = prefs.enabled;
   $('#blockingPaused').hidden = prefs.enabled;
   $('#blockingWordsTab').textContent = `屏蔽词 ${prefs.words.length}`;
@@ -74,19 +204,67 @@ function renderBlockingManager() {
     tab.setAttribute('aria-selected', String(active));
     tab.tabIndex = active ? 0 : -1;
   }
-  $('#blockingWordsPanel').hidden = currentTab !== 'words';
-  $('#blockingEntriesPanel').hidden = currentTab !== 'entries';
-  $('#blockingWordList').innerHTML = prefs.words.map(word => `<li${renderedWords.has(word) ? '' : ' class="is-new"'}><span>${esc(word)}</span><button type="button" data-remove-word="${esc(word)}" aria-label="取消屏蔽 ${esc(word)}">×</button></li>`).join('');
-  renderedWords = new Set(prefs.words);
+  for (const [kind, view] of Object.entries(views)) {
+    view.hidden = kind !== currentTab;
+    view.inert = kind !== currentTab;
+    view.setAttribute('aria-hidden', String(kind !== currentTab));
+  }
+  reconcileBlockingList('words', lists.words, prefs.words, snapshots.words, moving && tab === previousTab && tab === 'words', motions);
+  reconcileBlockingList('entries', lists.entries, prefs.entries.slice(0, shownEntries), snapshots.entries,
+    moving && tab === previousTab && tab === 'entries', motions);
   $('#blockingWordsEmpty').hidden = Boolean(prefs.words.length);
-  $('#blockingEntryList').innerHTML = prefs.entries.slice(0, shownEntries).map(item => {
-    const locked = isCodexLocked(findCodexMeta(item.codexId)) || isEntryAccessBlocked({ ...item, _srcCodexId: item.codexId });
-    const title = locked ? '受限卡片' : item.title;
-    const source = locked ? '开启相应内容分级后可查看名称' : item.codexTitle;
-    return `<li><div><b>${esc(title)}</b><span>${esc(source)}</span></div><button type="button" class="panel-action is-sm" data-restore-entry="${esc(item.key)}" aria-label="恢复 ${esc(title)}">恢复</button></li>`;
-  }).join('');
   $('#blockingEntriesEmpty').hidden = Boolean(prefs.entries.length);
   $('#blockingMoreEntries').hidden = prefs.entries.length <= shownEntries;
+  if (moving) animateManagerChange(shell, views, { previousTab, oldHeight, oldOpacity, oldTranslate, motions });
+  if (moving && tab === previousTab && focusedIndex >= 0) {
+    const retained = [...renderedLists[tab].values()];
+    const target = focused.isConnected && !focused.closest('[inert]') ? focused
+      : retained[Math.min(focusedIndex, retained.length - 1)]?.querySelector('button')
+        || (tab === 'words' ? $('#blockingWordInput') : $('#blockingEntriesTab'));
+    if (document.activeElement !== target) target.focus({ preventScroll: true });
+  }
+}
+
+function animateManagerChange(shell, views, { previousTab, oldHeight, oldOpacity, oldTranslate, motions }) {
+  const previous = views[previousTab];
+  const next = views[currentTab];
+  const changedTab = previous !== next;
+  const newHeight = shell.getBoundingClientRect().height;
+  const shellStyle = shell.style.cssText;
+  const previousStyle = previous.style.cssText;
+  let timer;
+  const finish = () => {
+    if (finishManagerMotion !== finish) return;
+    finishManagerMotion = null;
+    clearTimeout(timer);
+    for (const element of motions.keys()) cancelUiMotion(element);
+    if (changedTab) previous.hidden = true;
+    previous.style.cssText = previousStyle;
+    shell.style.cssText = shellStyle;
+  };
+  finishManagerMotion = finish;
+  const play = (element, frames, options) => {
+    const animation = animateUi(element, frames, options);
+    if (animation) motions.set(element, animation);
+    return animation;
+  };
+  if (changedTab) {
+    const direction = currentTab === 'entries' ? 1 : -1;
+    previous.hidden = false;
+    Object.assign(previous.style, { position: 'absolute', inset: '0 0 auto', pointerEvents: 'none' });
+    const outgoing = play(previous, [
+      { opacity: oldOpacity, translate: oldTranslate }, { opacity: 0, translate: `${-direction * 8}px 0` },
+    ], { duration: 150, easing: 'ease-out' });
+    play(next, [{ opacity: 0, translate: `${direction * 10}px 0` }, { opacity: 1, translate: '0 0' }]);
+    outgoing?.finished.then(() => { if (finishManagerMotion === finish) previous.hidden = true; }, () => {});
+  }
+  if (Math.abs(oldHeight - newHeight) > .5) {
+    play(shell, [{ height: `${oldHeight}px` }, { height: `${newHeight}px` }]);
+  }
+  if (!motions.size) { finish(); return; }
+  shell.style.overflow = 'clip';
+  timer = setTimeout(finish, 320);
+  Promise.allSettled([...motions.values()].map(animation => animation.finished)).then(finish);
 }
 
 export function promptBlockedEntry(entry, reveal) {
@@ -108,14 +286,22 @@ export function promptBlockedEntry(entry, reveal) {
 export function setupContentBlocking() {
   const mask = $('#contentBlocking');
   if (!mask) return;
+  // 浏览器 Back 也会走共享遮罩状态；关闭时清掉退场残影和未完成的高度动画。
+  new MutationObserver(() => {
+    if (mask.hidden || !mask.classList.contains('show')) settleManagerMotion();
+  }).observe(mask, { attributes: true, attributeFilter: ['class', 'hidden'] });
+  const closePanel = panel => {
+    if (panel === mask) settleManagerMotion();
+    closeMask(panel);
+  };
   $('#blockingSettingsBtn').onclick = event => openBlockingManager(event.currentTarget);
   $('#blockingResultBtn').onclick = event => openBlockingManager(event.currentTarget);
   for (const [id, closeId] of [['contentBlocking', 'blockingClose'], ['blockingReveal', 'blockingRevealClose']]) {
     const panel = $(`#${id}`);
-    $(`#${closeId}`).onclick = () => closeMask(panel);
-    bindBackdropDismiss(panel, () => closeMask(panel));
+    $(`#${closeId}`).onclick = () => closePanel(panel);
+    bindBackdropDismiss(panel, () => closePanel(panel));
     panel.addEventListener('keydown', event => {
-      if (event.key === 'Escape') { event.preventDefault(); event.stopPropagation(); closeMask(panel); }
+      if (event.key === 'Escape') { event.preventDefault(); event.stopPropagation(); closePanel(panel); }
       else trapFocus(event, panel);
     });
   }
@@ -127,7 +313,7 @@ export function setupContentBlocking() {
     if (event.key === 'Escape') {
       event.preventDefault();
       event.stopImmediatePropagation();
-      closeMask(top);
+      closePanel(top);
     } else if (event.key === 'Tab' && !top.contains(document.activeElement)) {
       event.preventDefault();
       event.stopImmediatePropagation();
@@ -138,7 +324,10 @@ export function setupContentBlocking() {
   $('#blockingEnabled').onchange = event => {
     if (showSaveError(setContentBlockingEnabled(event.target.checked))) renderBlockingManager();
   };
-  const chooseTab = tab => { currentTab = tab.dataset.blockingTab; renderBlockingManager(); tab.focus(); };
+  const chooseTab = tab => {
+    if (currentTab !== tab.dataset.blockingTab) renderBlockingManager({ tab: tab.dataset.blockingTab });
+    tab.focus({ preventScroll: true });
+  };
   const tabs = [...mask.querySelectorAll('[data-blocking-tab]')];
   tabs.forEach((tab, index) => {
     tab.onclick = () => chooseTab(tab);
@@ -165,13 +354,11 @@ export function setupContentBlocking() {
   };
   $('#blockingWordList').onclick = event => {
     const button = event.target.closest('[data-remove-word]');
-    if (button && !showSaveError(removeBlockedWord(button.dataset.removeWord))) $('#blockingWordInput').focus();
+    if (button && !button.closest('[inert]')) showSaveError(removeBlockedWord(button.dataset.removeWord));
   };
   $('#blockingEntryList').onclick = event => {
     const button = event.target.closest('[data-restore-entry]');
-    if (button && !showSaveError(restoreContentEntry(button.dataset.restoreEntry))) {
-      ($('#blockingEntryList button') || $('#blockingEntriesTab')).focus();
-    }
+    if (button && !button.closest('[inert]')) showSaveError(restoreContentEntry(button.dataset.restoreEntry));
   };
   $('#blockingMoreEntries').onclick = () => { shownEntries += 40; renderBlockingManager(); };
   subscribeContentBlocking(() => { actions.refresh(); renderBlockingManager(); updateBlockingSummary(); });

--- a/site/assets/app/content-blocking.js
+++ b/site/assets/app/content-blocking.js
@@ -1,0 +1,104 @@
+import { state } from './state.js';
+import { findCodexMeta } from './data.js';
+import { atlasFavoriteStorageKeys, createCodexLookup } from './favorites-backup-core.js';
+import {
+  BLOCKING_STORAGE_KEY, BLOCKING_WORD_LIMIT, BLOCKING_ENTRY_LIMIT,
+  normalizeBlockedWord, normalizeBlockingPreferences, compileBlockedWords, positiveBlockingFields, matchBlockedWord,
+} from './content-blocking-core.js';
+
+let preferences = normalizeBlockingPreferences(null);
+let compiled = [];
+let hiddenKeys = new Set();
+let entryMatches = new WeakMap();
+let lookupSource = null;
+let lookup = null;
+const listeners = new Set();
+
+function install(value) {
+  preferences = normalizeBlockingPreferences(value);
+  compiled = compileBlockedWords(preferences.words);
+  hiddenKeys = new Set(preferences.entries.map(item => item.key));
+  entryMatches = new WeakMap();
+}
+
+export function loadContentBlocking() {
+  try { install(JSON.parse(localStorage.getItem(BLOCKING_STORAGE_KEY) || 'null')); }
+  catch { install(null); }
+}
+
+export function getBlockingPreferences() {
+  return { ...preferences, words: [...preferences.words], entries: preferences.entries.map(item => ({ ...item })) };
+}
+
+export function subscribeContentBlocking(listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function receiveBlockingStorage(event) {
+  if (event.storageArea !== localStorage || (event.key !== null && event.key !== BLOCKING_STORAGE_KEY)) return;
+  loadContentBlocking();
+  listeners.forEach(listener => listener());
+}
+
+function save(next) {
+  const normalized = normalizeBlockingPreferences(next);
+  try { localStorage.setItem(BLOCKING_STORAGE_KEY, JSON.stringify(normalized)); }
+  catch { return { error: '无法保存屏蔽清单，清空最近浏览或复制历史后重试' }; }
+  install(normalized);
+  listeners.forEach(listener => listener());
+  return { ok: true };
+}
+
+export function contentBlockingKeys(entry) {
+  const sourceId = entry?._srcCodexId || state.codex?.id;
+  if (!sourceId || !entry?.id) return [];
+  if (lookupSource !== state.codexes) {
+    lookupSource = state.codexes;
+    lookup = createCodexLookup(state.codexes || []);
+  }
+  return atlasFavoriteStorageKeys({ codexId: sourceId, entryId: entry.id }, lookup);
+}
+
+export function invalidateBlockingEntry(entry) {
+  if (entry) entryMatches.delete(entry);
+}
+
+export function contentBlockReason(entry) {
+  if (!entry || !preferences.enabled) return null;
+  if (hiddenKeys.size && contentBlockingKeys(entry).some(key => hiddenKeys.has(key))) return { type: 'entry' };
+  if (!compiled.length) return null;
+  if (!entryMatches.has(entry)) entryMatches.set(entry, matchBlockedWord(positiveBlockingFields(entry), compiled));
+  const word = entryMatches.get(entry);
+  return word ? { type: 'word', word } : null;
+}
+
+export function isContentBlocked(entry) { return Boolean(contentBlockReason(entry)); }
+
+export function hideContentEntry(entry) {
+  const keys = contentBlockingKeys(entry);
+  if (!keys.length) return { error: '无法识别这张卡片的来源，刷新后重试' };
+  if (keys.some(key => hiddenKeys.has(key))) return { error: '这张卡片已在屏蔽清单中' };
+  if (preferences.entries.length >= BLOCKING_ENTRY_LIMIT) return { error: '已达到 5000 张卡片上限，在屏蔽管理中恢复部分卡片后重试' };
+  const source = findCodexMeta(entry._srcCodexId || state.codex?.id) || state.codex;
+  const record = { key: keys[0], codexId: source?.id || '', title: entry.title,
+    codexTitle: source?.title || '', rating: entry.rating || entry.level || '', path: entry._srcPath || entry.path || [] };
+  return { ...save({ ...preferences, entries: [record, ...preferences.entries.filter(item => !keys.includes(item.key))] }), key: record.key };
+}
+
+export function restoreContentEntry(key) {
+  return save({ ...preferences, entries: preferences.entries.filter(item => item.key !== key) });
+}
+
+export function addBlockedWords(input) {
+  const words = String(input || '').split(/[\n,，]+/).map(normalizeBlockedWord).filter(Boolean);
+  if (!words.length) return { error: '填写要屏蔽的词或短语' };
+  if (words.some(word => word.length > 80)) return { error: '每个词或短语最多 80 个字符' };
+  const all = [...new Set([...preferences.words, ...words])];
+  if (all.length > BLOCKING_WORD_LIMIT) return { error: '最多添加 100 个屏蔽词，移除部分词后重试' };
+  if (all.length === preferences.words.length) return { error: '这些词已在屏蔽清单中' };
+  return save({ ...preferences, words: all });
+}
+
+export function removeBlockedWord(word) { return save({ ...preferences, words: preferences.words.filter(item => item !== word) }); }
+export function setContentBlockingEnabled(enabled) { return save({ ...preferences, enabled: Boolean(enabled) }); }

--- a/site/assets/app/edit.js
+++ b/site/assets/app/edit.js
@@ -9,6 +9,7 @@ import { setCodexUiActions, closeCodexPicker, invalidateAccessViewMemo, syncCode
 import { openMask, closeMask, trapFocus, bindBackdropDismiss } from './modal.js';
 import { fetchDataJson } from '../data-source.js';
 import { invalidateSearchableText } from './search.js';
+import { invalidateBlockingEntry } from './content-blocking.js';
 import { invalidateSearchDirectories } from './search-directories.js';
 import { invalidateBodyMetrics } from './masonry.js';
 import { invalidateSiteSearchCodex } from './site-search.js';
@@ -384,6 +385,7 @@ async function saveEntry(entry) {
     mergeEntryInPlace(entry, res.entry);
     invalidateAccessViewMemo();
     invalidateSearchableText(entry);
+    invalidateBlockingEntry(entry);
     invalidateSearchDirectories(state.codex?.entries);
     invalidateBodyMetrics(entry);   // 标题/tag 改了，卡片估高缓存必须跟着失效，否则新文案还按旧高度排
     invalidateSiteSearchCodex();

--- a/site/assets/app/history.js
+++ b/site/assets/app/history.js
@@ -5,7 +5,9 @@ import { syncUrlState } from './router.js';
 import { normalizeCodexRoutePath } from './codex-route-compat.js';
 import { firstUnlockedCodex, isCodexLocked, isEntryNsfw, isNsfwPathSegment, isR18gEntry, showNsfwLockedHint, showR18gLockedHint } from './access.js';
 import { toast } from './feedback.js';
-import { findCodexMeta, resolveUpdateFilter, updateFilterDefinitions } from './data.js';
+import { findCodexMeta, fetchCodex, resolveUpdateFilter, updateFilterDefinitions } from './data.js';
+import { canonicalizeAtlasFavorite } from './favorites-backup-core.js';
+import { getBlockingPreferences, isContentBlocked } from './content-blocking.js';
 import { FAVORITES_CODEX_ID } from './fav-codex.js';
 import { SITE_SEARCH_CODEX_ID } from './site-search.js';
 import { isHistoryRestoreToken } from './browser-history.js';
@@ -250,14 +252,49 @@ export function formatRecentTime(ts) {
   return new Date(Number(ts)).toLocaleDateString('zh-CN');
 }
 
+const historyBlockingCodexes = new Map();
+
+function historyContentVisibility(item, preferences) {
+  if (!preferences.enabled || (!preferences.words.length && !preferences.entries.length)) return 'visible';
+  let identity;
+  try { identity = canonicalizeAtlasFavorite({ codexId: item.codexId, entryId: item.entryId }, state.codexes); }
+  catch { return 'hidden'; }
+  const snapshot = { id: identity.entryId, _srcCodexId: identity.codexId, title: item.title };
+  if (isContentBlocked(snapshot)) return 'hidden';
+  if (!preferences.words.length) return 'visible';
+  const meta = findCodexMeta(identity.codexId);
+  if (!meta) return 'hidden';
+  const cached = historyBlockingCodexes.get(meta.id);
+  const codex = state.codex?.id === meta.id ? state.codex : cached?.codex;
+  if (codex) {
+    const entry = codex.entries.find(entry => entry.id === identity.entryId);
+    return !entry || isContentBlocked({ ...entry, _srcCodexId: meta.id }) ? 'hidden' : 'visible';
+  }
+  if (cached) return cached.failed ? 'failed' : 'pending';
+  const record = {};
+  historyBlockingCodexes.set(meta.id, record);
+  fetchCodex(meta).then(codex => { record.codex = codex; }, () => { record.failed = true; }).finally(() => {
+    if ($('#historyPanel') && !$('#historyPanel').hidden) renderHistoryPanel();
+  });
+  return 'pending';
+}
+
 export function renderHistoryPanel() {
+  if ($('#historyPanel')?.hidden) {
+    for (const [key, value] of historyBlockingCodexes) if (value.failed) historyBlockingCodexes.delete(key);
+  }
   const resume = $('#resumeBrowse');
   const resumeDesc = $('#resumeDesc');
   const resumeLocked = isHistoryItemLocked(state.lastBrowse);
   if (resumeDesc) resumeDesc.textContent = browseDesc(state.lastBrowse);
   if (resume) resume.disabled = !state.lastBrowse || Boolean(resumeLocked);
   const clearBtn = $('#clearRecent');
-  const recentEntries = state.recentEntries.filter(item => !isHistoryItemLocked(item));
+  const preferences = getBlockingPreferences();
+  const accessibleEntries = state.recentEntries.filter(item => !isHistoryItemLocked(item));
+  const checked = accessibleEntries.map(item => ({ item, visibility: historyContentVisibility(item, preferences) }));
+  const recentEntries = checked.filter(item => item.visibility === 'visible').map(item => item.item);
+  const pending = checked.some(item => item.visibility === 'pending');
+  const failed = checked.some(item => item.visibility === 'failed');
   if (clearBtn) clearBtn.disabled = recentEntries.length === 0;
 
   const list = $('#recentList');
@@ -267,7 +304,9 @@ export function renderHistoryPanel() {
     const empty = document.createElement('div');
     empty.className = 'recent-empty';
     empty.textContent = state.recentEntries.length
-      ? '最近记录中只有当前已隐藏的限制级内容。开启对应内容权限后可查看。'
+      ? (pending ? '正在检查最近记录…' : failed ? '部分记录加载失败，重新打开此面板可重试。'
+        : accessibleEntries.length ? '最近记录已被屏蔽，可在设置中管理屏蔽清单。'
+          : '最近记录中只有当前已隐藏的限制级内容。开启对应内容权限后可查看。')
       : '最近还没有打开过词条。点卡片放大图或复制词条后，这里会自动记录。';
     list.appendChild(empty);
     return;
@@ -309,6 +348,12 @@ export function renderHistoryPanel() {
     btn.appendChild(time);
     btn.onclick = () => document.dispatchEvent(new CustomEvent('openRecentEntry', { detail: item }));
     list.appendChild(btn);
+  }
+  if (pending || failed) {
+    const notice = document.createElement('p');
+    notice.className = 'recent-empty';
+    notice.textContent = pending ? '正在检查其余记录…' : '部分记录加载失败，重新打开此面板可重试。';
+    list.appendChild(notice);
   }
 }
 

--- a/site/assets/app/lightbox.js
+++ b/site/assets/app/lightbox.js
@@ -15,6 +15,8 @@ import {
 } from './original-capability.js';
 import { isEntryAccessBlocked, isR18gBlocked, showNsfwLockedHint, showR18gLockedHint } from './access.js';
 import { openReportDialog } from './report.js';
+import { isContentBlocked } from './content-blocking.js';
+import { hideCard, promptBlockedEntry } from './content-blocking-ui.js';
 import { goBackFrom } from './browser-history.js';
 import { bindBackdropDismiss } from './modal.js';
 import {
@@ -78,7 +80,7 @@ export function lightboxNavigationContext(entry = state.lightbox.entry, list = s
   let exactIndex = -1;
   let equivalentIndex = -1;
   for (const candidate of list) {
-    if (!hasEntryImage(candidate) || isEntryAccessBlocked(candidate)) continue;
+    if (!hasEntryImage(candidate) || isEntryAccessBlocked(candidate) || isContentBlocked(candidate)) continue;
     const index = entries.length;
     entries.push(candidate);
     if (candidate === entry) exactIndex = index;
@@ -256,6 +258,13 @@ export function openLightbox(entry, index = 0, sourceEl = null, options = {}) {
   const parentScrollY = Math.max(0, window.scrollY || 0);
   if (isR18gBlocked(entry)) { showR18gLockedHint(); return; }  // 深链/最近记录等绕过路径的兜底拦截
   if (isLightboxEntryAccessBlocked(entry)) { showNsfwLockedHint(); return; }
+  if (!options.allowContentBlocked && isContentBlocked(entry)) {
+    syncUrlState({ entry: '', historyMode: 'replace' });
+    promptBlockedEntry(entry, () => openLightbox(entry, index, null, {
+      ...options, allowContentBlocked: true, consumeLayer: true, historyMode: 'push',
+    }));
+    return;
+  }
   const sourceImages = entryImages(entry);
   const images = sourceImages.length
     ? sourceImages
@@ -662,6 +671,12 @@ export function renderLightbox() {
   }
 
   $('#lightboxTitle').textContent = e.title;
+  const hideButton = $('#hideLightbox');
+  if (hideButton) {
+    hideButton.disabled = isContentBlocked(e);
+    hideButton.textContent = hideButton.disabled ? '已屏蔽' : '不想看';
+    hideButton.onclick = () => hideCard(e);
+  }
   const nav = lightboxNavigationContext(e, state.list);
   const entryPosition = nav.index >= 0 ? ` · 第 ${nav.position} / ${nav.total} 条` : '';
   $('#lightboxMeta').textContent = emptyImage

--- a/site/assets/app/masonry.js
+++ b/site/assets/app/masonry.js
@@ -13,6 +13,7 @@ const masonryActions = {
   copyEntry: () => {},
   toggleFav: () => {},
   reportEntry: () => {},
+  hideCard: () => {},
 };
 
 const FILTER_EXIT_MS = 140;
@@ -482,6 +483,15 @@ export function makeCard(placement) {
   fav.onclick = ev => { ev.stopPropagation(); masonryActions.toggleFav(e, fav); };
 
   const reportBtn = node.querySelector('.report-card-btn');
+  const hideBtn = node.querySelector('.hide-card-btn');
+  if (hideBtn) hideBtn.onclick = ev => {
+    ev.stopPropagation();
+    if (node.classList.contains('card-leaving')) return;
+    if (prefersReducedMotion()) { masonryActions.hideCard(e); return; }
+    // 与筛选切换同一套退场：先淡出这一张，再让屏蔽清单触发重排把空位收掉。
+    node.classList.add('card-leaving');
+    window.setTimeout(() => masonryActions.hideCard(e), FILTER_EXIT_MS + FILTER_EXIT_PAD_MS);
+  };
   if (reportBtn) {
     reportBtn.onclick = ev => {
       ev.stopPropagation();

--- a/site/assets/app/masonry.js
+++ b/site/assets/app/masonry.js
@@ -7,6 +7,7 @@ import { hasEntryImage, entryImages, thumbUrl, localAssetUrl, cacheBustUrl } fro
 import { copyText, combinedPrompt, combinedPromptLabel, entryPromptText } from './copy.js';
 import { isFav } from './favorites.js';
 import { updateReadingSpy } from './codex-ui.js';
+import { animateUi, cancelUiMotion } from './ui-motion.js';
 
 const masonryActions = {
   openLightbox: () => {},
@@ -23,6 +24,108 @@ let filterTransitionSeq = 0;
 let filterTransitionTimer = 0;
 let forceEntryAnim = false;
 let suppressNextInitialEntryBatch = false;
+const retiringCards = new Map();
+let blockingMotionTimer = 0;
+
+function finishBlockingMotion() {
+  clearTimeout(blockingMotionTimer);
+  blockingMotionTimer = 0;
+  $('#masonry')?.classList.remove('is-blocking-update', 'has-retiring-cards');
+  for (const retirement of retiringCards.values()) {
+    clearTimeout(retirement.timer);
+    cancelUiMotion(retirement.node);
+    cleanupCard(retirement.node);
+    retirement.node.remove();
+  }
+  retiringCards.clear();
+}
+
+function retireCard(entry, node, animate) {
+  const visual = getComputedStyle(node);
+  const opacity = visual.opacity;
+  const transform = visual.transform;
+  settleCardEntry(node);
+  // 连点时可能仍在上一轮补位中；退场固定此刻的位置，不先跳到补位终点。
+  node.style.transform = transform;
+  node.inert = true;
+  node.setAttribute('aria-hidden', 'true');
+  node.classList.add('card-retiring');
+  delete node.dataset.index;
+  if (!animate) { cleanupCard(node); node.remove(); return; }
+  const retirement = { node, timer: 0 };
+  retiringCards.set(entry, retirement);
+  $('#masonry')?.classList.add('has-retiring-cards');
+  const finish = () => {
+    if (retiringCards.get(entry) !== retirement) return;
+    retiringCards.delete(entry);
+    clearTimeout(retirement.timer);
+    cleanupCard(node);
+    node.remove();
+    if (!retiringCards.size) $('#masonry')?.classList.remove('has-retiring-cards');
+  };
+  const animation = animateUi(node, [{ opacity }, { opacity: 0 }], { duration: FILTER_EXIT_MS, easing: 'linear' });
+  retirement.timer = window.setTimeout(finish, FILTER_EXIT_MS + FILTER_EXIT_PAD_MS);
+  if (animation) animation.finished.then(finish, finish);
+  else finish();
+}
+
+// 屏蔽只改变当前结果的成员：保留未变卡片的 DOM、图片与实测高度。
+// 业务列表当场更新，离场节点仅作短暂视觉残影，不再参与交互或虚拟列表索引。
+function renderBlockingList(m) {
+  const previous = new Map(state.placements.map(p => [p.entry, p]));
+  const nodes = new Map(state.placements.map(p => [p.entry, state.nodes.get(p.index)]));
+  const active = document.activeElement;
+  const lostFocusIndex = [...state.nodes].find(([, node]) => node.contains(active))?.[0];
+  const animate = !prefersReducedMotion() && !document.documentElement.classList.contains('motion-off');
+  clearTimeout(blockingMotionTimer);
+  clearTimeout(relayoutAnimTimer);
+  relayoutAnimating = false;
+  m.classList.remove('is-relayouting');
+  m.classList.toggle('is-blocking-update', animate);
+  if (animate) void m.offsetWidth;
+  computeLayout({ previous });
+  const remaining = new Set(state.list);
+  for (const [entry, node] of nodes) {
+    if (node && !remaining.has(entry)) retireCard(entry, node, animate);
+  }
+  state.nodes.clear();
+  for (const placement of state.placements) {
+    const retirement = retiringCards.get(placement.entry);
+    const node = nodes.get(placement.entry) || retirement?.node;
+    if (!node) continue;
+    if (retirement) {
+      retiringCards.delete(placement.entry);
+      clearTimeout(retirement.timer);
+      cancelUiMotion(node);
+      node.classList.remove('card-retiring');
+      node.inert = false;
+      node.removeAttribute('aria-hidden');
+    }
+    node.dataset.index = String(placement.index);
+    state.nodes.set(placement.index, node);
+  }
+  if (!retiringCards.size) m.classList.remove('has-retiring-cards');
+  updateVirtualCards(true);
+  // 恢复/撤销可能把卡插回中间；只移动顺序真正变化的节点，不重插整屏图片。
+  const nextLive = node => {
+    while (node?.classList.contains('card-retiring')) node = node.nextElementSibling;
+    return node;
+  };
+  let cursor = nextLive(m.firstElementChild);
+  for (const [, node] of [...state.nodes].sort(([a], [b]) => a - b)) {
+    if (node !== cursor) m.insertBefore(node, cursor);
+    cursor = nextLive(node.nextElementSibling);
+  }
+  if (lostFocusIndex !== undefined && (!active.isConnected || active.closest('[inert]'))) {
+    const next = state.nodes.get(lostFocusIndex) || [...state.nodes.values()].at(-1);
+    (next?.querySelector('.hide-card-btn') || $('#blockingResultBtn'))?.focus({ preventScroll: true });
+  }
+  if (animate) blockingMotionTimer = window.setTimeout(() => {
+    blockingMotionTimer = 0;
+    m.classList.remove('is-blocking-update');
+  }, 320);
+  updateScrollProgress();
+}
 
 export function setMasonryActions(actions = {}) {
   Object.assign(masonryActions, actions);
@@ -108,6 +211,7 @@ export function colCount() {
 }
 
 export function clearMasonry() {
+  finishBlockingMotion();
   cleanupFilterTransition();
   for (const node of state.nodes.values()) cleanupCard(node);
   state.nodes.clear();
@@ -127,7 +231,14 @@ export function renderList({ resetScroll = false, transition = 'none' } = {}) {
   const m = $('#masonry');
   const shouldTransition = canRunFilterTransition(m, transition);
   const seq = ++filterTransitionSeq;
+  const interruptedFilter = Boolean(filterTransitionTimer);
   cleanupFilterTransition(m);
+
+  // 搜索退场中仍是旧高亮/命中提示；此时不能把旧 DOM 当作当前结果复用。
+  if (transition === 'blocking' && !interruptedFilter && m && state.placements.length && !resetScroll) {
+    renderBlockingList(m);
+    return;
+  }
 
   if (!shouldTransition) {
     renderListNow({ resetScroll, forceEntry: canForceFilterEntry(transition) });
@@ -165,7 +276,7 @@ export function renderList({ resetScroll = false, transition = 'none' } = {}) {
   }, maxDelay + FILTER_EXIT_MS + FILTER_EXIT_PAD_MS);
 }
 
-export function computeLayout() {
+export function computeLayout({ previous } = {}) {
   const m = $('#masonry');
   const width = Math.max(1, m.clientWidth || $('#main').clientWidth || 1);
   const cfg = densityConfig();
@@ -177,9 +288,11 @@ export function computeLayout() {
   for (let i = 0; i < state.list.length; i++) {
     const entry = state.list[i];
     const col = shortestIndex(colHeights);
-    const imageHeight = estimateImageHeight(entry, itemWidth);
+    const measured = previous?.get(entry);
+    const retained = measured?.width === itemWidth ? measured : null;
+    const imageHeight = retained?.imageHeight ?? estimateImageHeight(entry, itemWidth);
     const body = estimateBodyMetrics(entry, itemWidth);
-    const height = Math.ceil(imageHeight + body.height);
+    const height = retained?.height ?? Math.ceil(imageHeight + body.height);
     const left = col * (itemWidth + cfg.gap);
     const top = colHeights[col];
 
@@ -192,7 +305,7 @@ export function computeLayout() {
       width: itemWidth,
       height,
       imageHeight,
-      tagsHeight: body.tagsHeight,
+      tagsHeight: retained?.tagsHeight ?? body.tagsHeight,
     });
     colHeights[col] += height + cfg.gap;
   }
@@ -486,11 +599,8 @@ export function makeCard(placement) {
   const hideBtn = node.querySelector('.hide-card-btn');
   if (hideBtn) hideBtn.onclick = ev => {
     ev.stopPropagation();
-    if (node.classList.contains('card-leaving')) return;
-    if (prefersReducedMotion()) { masonryActions.hideCard(e); return; }
-    // 与筛选切换同一套退场：先淡出这一张，再让屏蔽清单触发重排把空位收掉。
-    node.classList.add('card-leaving');
-    window.setTimeout(() => masonryActions.hideCard(e), FILTER_EXIT_MS + FILTER_EXIT_PAD_MS);
+    // 保存成功后的订阅刷新负责退场；错误时保留原卡，来源也不会被迟到回调改写。
+    masonryActions.hideCard(e);
   };
   if (reportBtn) {
     reportBtn.onclick = ev => {
@@ -893,6 +1003,7 @@ export function notifyImageLoadError(e) {
 }
 
 export function cleanupCard(node) {
+  cancelUiMotion(node);
   if (node._imageTimer) {
     clearTimeout(node._imageTimer);
     node._imageTimer = 0;
@@ -941,6 +1052,7 @@ export function startRelayoutAnimation() {
 
 export function relayoutVisible({ animate = false } = {}) {
   if (!state.codex) return;
+  finishBlockingMotion();
   if (animate) startRelayoutAnimation();
   computeLayout();
   updateVirtualCards(true);

--- a/site/assets/app/report.js
+++ b/site/assets/app/report.js
@@ -324,7 +324,7 @@ function selectFeedbackTab(value) {
   if (open && nextView && !nextView.hidden) return;
   const changed = Boolean(nextView?.hidden);
   cancelFeedbackTabMotion();
-  mask?.querySelector('.feedback-tabs')?.style.setProperty('--feedback-tab-index', tab === 'progress' ? '1' : '0');
+  mask?.querySelector('.feedback-tabs')?.style.setProperty('--seg-index', tab === 'progress' ? '1' : '0');
   document.querySelectorAll('[data-feedback-tab]').forEach(button => {
     const active = button.dataset.feedbackTab === tab;
     button.setAttribute('aria-selected', active ? 'true' : 'false');

--- a/site/assets/app/ui.js
+++ b/site/assets/app/ui.js
@@ -1049,6 +1049,7 @@ export function bindUI() {
     return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el?.isContentEditable;
   };
   const overlayOpen = () =>
+    Boolean(document.querySelector('#contentBlocking.show, #blockingReveal.show')) ||
     !$('#lightbox').hidden ||
     !settingsMask.hidden ||
     !nsfwMask.hidden ||

--- a/site/assets/content-blocking.css
+++ b/site/assets/content-blocking.css
@@ -32,6 +32,7 @@ body.density-compact .hide-card-btn svg{width:14px;height:14px}
 
 /* 分栏：几何、滑块与选中态全部来自 .seg-tabs，这里只给外边距 */
 .blocking-tabs{margin:14px 0 16px}
+.blocking-views{position:relative;display:flow-root;min-width:0}
 
 /* 添加屏蔽词：字段几何与高级搜索面板的字段一致（36px / 9px / 三像素焦点光晕） */
 .blocking-word-form>label{display:block;margin-bottom:6px;color:var(--muted);font-size:12px;font-weight:600}
@@ -48,7 +49,7 @@ body.density-compact .hide-card-btn svg{width:14px;height:14px}
 .blocking-error{margin:9px 0 0;color:var(--danger-text);font-size:12px;line-height:1.5}
 
 /* 已屏蔽的词：沿用高级搜索“已加条件”胶囊的形制 */
-.blocking-word-list{list-style:none;display:flex;flex-wrap:wrap;gap:7px;margin:16px 0 0;padding:0}
+.blocking-word-list{position:relative;list-style:none;display:flex;flex-wrap:wrap;gap:7px;margin:16px 0 0;padding:0}
 .blocking-word-list li{
   min-height:28px;max-width:100%;border:1px solid color-mix(in srgb,var(--accent) 30%,var(--line));border-radius:999px;
   display:inline-flex;align-items:center;background:var(--accent-soft);color:var(--text);overflow:hidden;
@@ -56,14 +57,14 @@ body.density-compact .hide-card-btn svg{width:14px;height:14px}
 .blocking-word-list li>span{min-width:0;padding:3px 2px 3px 11px;font-size:12px;font-weight:600;overflow-wrap:anywhere}
 .blocking-word-list button{
   flex:none;align-self:stretch;width:28px;border:0;background:transparent;color:var(--muted);
-  font-size:16px;line-height:1;cursor:pointer;transition:background .15s,color .15s;
+  font-size:16px;line-height:1;cursor:pointer;transition:background .15s,color .15s,scale .12s ease;
 }
 .blocking-word-list button:is(:hover,:focus-visible){background:color-mix(in srgb,var(--accent) 12%,transparent);color:var(--accent)}
 
 /* 单独隐藏的卡片：与设置面板的条目行同构 */
-.blocking-entry-list{list-style:none;margin:0;padding:0}
+.blocking-entry-list{position:relative;list-style:none;margin:0;padding:0}
 .blocking-entry-list li{display:flex;align-items:center;gap:12px;padding:13px 2px;border-bottom:1px solid var(--line)}
-.blocking-entry-list li:last-child{border-bottom:none}
+.blocking-entry-list li.is-last{border-bottom:none}
 .blocking-entry-list li>div{min-width:0;flex:1;display:flex;flex-direction:column;gap:2px}
 .blocking-entry-list b{font-size:14px;font-weight:600;overflow-wrap:anywhere}
 .blocking-entry-list span{color:var(--muted);font-size:12px;overflow-wrap:anywhere}
@@ -76,12 +77,8 @@ body.density-compact .hide-card-btn svg{width:14px;height:14px}
   margin-top:18px;padding-top:14px;border-top:1px solid var(--line);
 }
 
-/* 新加的屏蔽词单独入场；整表是 innerHTML 重绘，靠 .is-new 只点亮真正新增的那几个。 */
-@keyframes blockingChipIn{from{opacity:0;scale:.9}to{opacity:1;scale:1}}
-.blocking-word-list li.is-new{animation:blockingChipIn .22s cubic-bezier(.22,1,.36,1)}
-/* 切页签时内容淡入；同一页签内的重绘不改 display，动画不会重放。 */
-@keyframes blockingPanelIn{from{opacity:0;translate:0 4px}to{opacity:1;translate:0 0}}
-#blockingWordsPanel,#blockingEntriesPanel{animation:blockingPanelIn .2s ease}
+/* 清单增删、补位与页签高度由 ui-motion 持有，关闭或快速操作会结清旧轮。 */
+.blocking-word-list [data-blocking-exit],.blocking-entry-list [data-blocking-exit]{pointer-events:none}
 .blocking-word-list button:active{scale:.94}
 
 @media (max-width:600px){
@@ -92,5 +89,4 @@ body.density-compact .hide-card-btn svg{width:14px;height:14px}
 @media (prefers-reduced-motion:reduce){
   .hide-card-btn,.blocking-word-list button{transition:none!important}
   .fav-btn:active,.hide-card-btn:active,.blocking-word-list button:active{scale:1}
-  .blocking-word-list li.is-new,#blockingWordsPanel,#blockingEntriesPanel{animation:none!important}
 }

--- a/site/assets/content-blocking.css
+++ b/site/assets/content-blocking.css
@@ -1,0 +1,96 @@
+/* 个人屏蔽功能的专有样式。
+   通用件一律复用主站已有的件：结果栏入口用 .bar-btn、面板动作用 .panel-action、
+   分栏用与反馈面板同构的凹槽分段控件、输入框对齐高级搜索的字段。
+   这里只留屏蔽独有的部分——新增控件请先在主站找同源件，别在本文件另起一套尺寸。 */
+
+/* 卡片上的“不想看”：与同排的 .fav-btn 同规格，否则会把整栏标题行从 20px 撑到 28px */
+.hide-card-btn{
+  flex:none;border:none;background:transparent;cursor:pointer;
+  padding:2px 5px;border-radius:7px;line-height:1;color:var(--muted);
+  display:grid;place-items:center;
+  transition:background .12s,color .12s,scale .12s ease;
+}
+/* 按压幅度与 .fav-btn 同值，两个按钮就在一起，不能一个跟手一个不动。 */
+.hide-card-btn:active{scale:.88}
+.hide-card-btn svg{
+  display:block;width:16px;height:16px;fill:none;stroke:currentColor;
+  stroke-width:1.9;stroke-linecap:round;stroke-linejoin:round;
+}
+.hide-card-btn:is(:hover,:focus-visible){background:var(--tagbg);color:var(--accent)}
+body.density-compact .hide-card-btn{padding:1px 3px;border-radius:6px}
+body.density-compact .hide-card-btn svg{width:14px;height:14px}
+
+/* 结果栏入口的几何、字重和过渡都来自 .bar-btn，这里只挂 z 序与面板骨架 */
+#contentBlocking,#blockingReveal{z-index:110}
+#contentBlocking{z-index:111}
+.blocking-panel,.blocking-reveal-panel{padding-bottom:18px}
+
+/* 启用开关行：与设置面板里的条目同构（细线分隔，不是灰色色块） */
+.blocking-enable-row{display:flex;align-items:center;gap:10px;padding:13px 2px;border-bottom:1px solid var(--line)}
+.blocking-enable-row>label:first-child{flex:1;min-width:0;font-size:14px;font-weight:600}
+.blocking-paused{margin-top:10px}
+
+/* 分栏：几何、滑块与选中态全部来自 .seg-tabs，这里只给外边距 */
+.blocking-tabs{margin:14px 0 16px}
+
+/* 添加屏蔽词：字段几何与高级搜索面板的字段一致（36px / 9px / 三像素焦点光晕） */
+.blocking-word-form>label{display:block;margin-bottom:6px;color:var(--muted);font-size:12px;font-weight:600}
+.blocking-input-row{display:flex;align-items:center;gap:8px}
+.blocking-input-row input{
+  min-width:0;flex:1;min-height:36px;border:1px solid var(--line);border-radius:9px;padding:0 10px;
+  background:var(--card);color:var(--text);font:inherit;font-size:13px;outline:none;
+  transition:border-color .16s,box-shadow .16s,background .16s;
+}
+.blocking-input-row input:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft)}
+.blocking-input-row input[aria-invalid="true"]{border-color:var(--danger);box-shadow:0 0 0 3px color-mix(in srgb,var(--danger) 12%,transparent)}
+.blocking-input-row input::placeholder{color:var(--muted)}
+.blocking-hint{margin:9px 0 0;color:var(--muted);font-size:12px;line-height:1.7}
+.blocking-error{margin:9px 0 0;color:var(--danger-text);font-size:12px;line-height:1.5}
+
+/* 已屏蔽的词：沿用高级搜索“已加条件”胶囊的形制 */
+.blocking-word-list{list-style:none;display:flex;flex-wrap:wrap;gap:7px;margin:16px 0 0;padding:0}
+.blocking-word-list li{
+  min-height:28px;max-width:100%;border:1px solid color-mix(in srgb,var(--accent) 30%,var(--line));border-radius:999px;
+  display:inline-flex;align-items:center;background:var(--accent-soft);color:var(--text);overflow:hidden;
+}
+.blocking-word-list li>span{min-width:0;padding:3px 2px 3px 11px;font-size:12px;font-weight:600;overflow-wrap:anywhere}
+.blocking-word-list button{
+  flex:none;align-self:stretch;width:28px;border:0;background:transparent;color:var(--muted);
+  font-size:16px;line-height:1;cursor:pointer;transition:background .15s,color .15s;
+}
+.blocking-word-list button:is(:hover,:focus-visible){background:color-mix(in srgb,var(--accent) 12%,transparent);color:var(--accent)}
+
+/* 单独隐藏的卡片：与设置面板的条目行同构 */
+.blocking-entry-list{list-style:none;margin:0;padding:0}
+.blocking-entry-list li{display:flex;align-items:center;gap:12px;padding:13px 2px;border-bottom:1px solid var(--line)}
+.blocking-entry-list li:last-child{border-bottom:none}
+.blocking-entry-list li>div{min-width:0;flex:1;display:flex;flex-direction:column;gap:2px}
+.blocking-entry-list b{font-size:14px;font-weight:600;overflow-wrap:anywhere}
+.blocking-entry-list span{color:var(--muted);font-size:12px;overflow-wrap:anywhere}
+.blocking-empty{padding:22px 0 10px;text-align:center;color:var(--muted);font-size:13px;line-height:1.8}
+#blockingMoreEntries{display:block;margin:16px auto 0}
+
+/* 已屏蔽提示弹窗的动作区：与 .nsfw-actions 同构 */
+.blocking-reveal-actions{
+  display:flex;justify-content:flex-end;flex-wrap:wrap;gap:9px;
+  margin-top:18px;padding-top:14px;border-top:1px solid var(--line);
+}
+
+/* 新加的屏蔽词单独入场；整表是 innerHTML 重绘，靠 .is-new 只点亮真正新增的那几个。 */
+@keyframes blockingChipIn{from{opacity:0;scale:.9}to{opacity:1;scale:1}}
+.blocking-word-list li.is-new{animation:blockingChipIn .22s cubic-bezier(.22,1,.36,1)}
+/* 切页签时内容淡入；同一页签内的重绘不改 display，动画不会重放。 */
+@keyframes blockingPanelIn{from{opacity:0;translate:0 4px}to{opacity:1;translate:0 0}}
+#blockingWordsPanel,#blockingEntriesPanel{animation:blockingPanelIn .2s ease}
+.blocking-word-list button:active{scale:.94}
+
+@media (max-width:600px){
+  .blocking-input-row input{font-size:16px}
+  .blocking-reveal-actions{justify-content:flex-start}
+}
+
+@media (prefers-reduced-motion:reduce){
+  .hide-card-btn,.blocking-word-list button{transition:none!important}
+  .fav-btn:active,.hide-card-btn:active,.blocking-word-list button:active{scale:1}
+  .blocking-word-list li.is-new,#blockingWordsPanel,#blockingEntriesPanel{animation:none!important}
+}

--- a/site/assets/favorites-backup.css
+++ b/site/assets/favorites-backup.css
@@ -77,26 +77,9 @@
 .favorites-backup-section h3{margin:0;font-size:15px;line-height:1.4}
 .favorites-backup-section-heading p{margin:4px 0 0;color:var(--muted);font-size:12px;line-height:1.55}
 
-.favorites-backup-primary,
-.favorites-backup-secondary,
-.favorites-backup-danger,
-.favorites-backup-entry button,
-.favorites-backup-result-btn,
-.favorites-migration-banner button{
-  min-height:44px;border-radius:12px;padding:9px 15px;font:800 13px/1.25 var(--font-ui);
-  cursor:pointer;transition:background .15s,border-color .15s,color .15s,translate .15s,box-shadow .15s,opacity .15s;
-}
-.favorites-backup-primary{
-  flex:none;border:1px solid transparent;background:var(--accent);color:#fff;
-  box-shadow:0 8px 20px color-mix(in srgb,var(--accent) 22%,transparent);
-}
-.favorites-backup-primary:hover:not(:disabled){translate:0 -1px;filter:brightness(1.05)}
-.favorites-backup-primary:disabled{cursor:not-allowed;opacity:.46;box-shadow:none}
-.favorites-backup-secondary{border:1px solid var(--line);background:var(--card);color:var(--text)}
-.favorites-backup-secondary:hover{border-color:var(--accent);background:var(--accent-soft);color:var(--accent)}
-.favorites-backup-secondary:disabled{cursor:not-allowed;opacity:.46}
-.favorites-backup-danger{border:1px solid transparent;background:var(--red);color:#fff}
-.favorites-backup-danger:hover{translate:0 -1px;box-shadow:0 8px 20px color-mix(in srgb,var(--red) 24%,transparent)}
+/* 按钮的几何、字重、按压与禁用态全部来自 ui-kit.css 的 .panel-action / .bar-btn；
+   本文件只留这个弹窗的排布差异。「确认覆盖」改用 .is-danger 的语义红（不随主题换）。 */
+.favorites-backup-primary{flex:none}
 
 .favorites-backup-stats{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:9px;margin:14px 0 0}
 .favorites-backup-stats>div{
@@ -219,29 +202,23 @@ label.favorites-backup-file:has(+ .favorites-backup-file-input:focus-visible){ou
 .favorites-backup-entry-copy{min-width:0}
 .favorites-backup-entry b{display:block;color:var(--text);font-size:13px}
 .favorites-backup-entry small{display:block;margin-top:3px;color:var(--muted);font-size:11.5px;line-height:1.45}
-.favorites-backup-entry button,
-.favorites-backup-result-btn{
-  flex:none;border:1px solid var(--line);background:var(--card);color:var(--text);
-}
-.favorites-backup-entry button:hover,
-.favorites-backup-result-btn:hover{border-color:var(--accent);background:var(--accent-soft);color:var(--accent)}
+.favorites-backup-entry button{flex:none}
 
 /* 全部收藏结果栏入口：场景内一级操作；普通法典隐藏，移动端单独占一行。 */
+/* 场景内一级操作：形制仍是 .bar-btn，只把底色抬成 accent 淡底以示强调。 */
 .favorites-view-backup-btn{
-  display:inline-flex;align-items:center;justify-content:center;gap:7px;margin-left:auto;
+  margin-left:auto;gap:7px;
   border-color:color-mix(in srgb,var(--accent) 28%,var(--line));
   background:var(--accent-soft);color:var(--accent);
-  box-shadow:0 7px 18px color-mix(in srgb,var(--accent) 10%,transparent);
 }
-.favorites-view-backup-btn:hover{box-shadow:0 9px 22px color-mix(in srgb,var(--accent) 16%,transparent);translate:0 -1px}
-.favorites-view-backup-icon{font-size:17px;line-height:1}
+.favorites-view-backup-btn:hover{translate:0 -1px}
+.favorites-view-backup-icon{font-size:15px;line-height:1}
 
 /* 共创广场结果栏入口；独立一行容器可换行，不占顶栏空间。 */
 .community-result-row{
   display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;margin:2px 0 14px;
 }
 .community-result-row .result-bar{min-width:0;flex:1 1 220px;margin:0}
-.favorites-backup-result-btn{min-height:44px;border-radius:999px;padding-inline:15px}
 
 /* 自动复制被浏览器拒绝时，两页共用的可访问手动复制兜底。 */
 .clipboard-fallback-dialog{width:min(640px,100%)}
@@ -302,11 +279,5 @@ label.favorites-backup-file:has(+ .favorites-backup-file-input:focus-visible){ou
 @media(prefers-reduced-motion:reduce){
   .favorites-backup-mask,
   .favorites-backup-dialog,
-  .favorites-backup-primary,
-  .favorites-backup-secondary,
-  .favorites-backup-danger,
-  label.favorites-backup-file,
-  .favorites-backup-entry button,
-  .favorites-backup-result-btn,
-  .favorites-migration-banner button{transition:none!important}
+  label.favorites-backup-file{transition:none!important}
 }

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -957,6 +957,12 @@ button.crumb:hover{color:var(--accent);border-color:var(--accent);background:var
   transition:opacity .14s linear;
   transition-delay:var(--filter-delay,0ms);
 }
+.masonry.is-blocking-update .card:not(.card-retiring){
+  transition:transform .24s cubic-bezier(.22,1,.36,1),opacity .14s linear;
+}
+.card.card-retiring{opacity:0;pointer-events:none;transition:none}
+/* 列表高度立即采用新结果；末卡/尾卡只在短暂退场时允许画出新边界，结束恢复 paint containment。 */
+.masonry.has-retiring-cards{contain:layout}
 .masonry.is-relayouting .card{
   transition:
     transform .32s cubic-bezier(.22,1,.36,1),
@@ -2531,9 +2537,10 @@ html.vt-arrived.intro-arm .topbar,html.vt-arrived.intro-arm .sidebar,
 html.vt-arrived.intro-arm .main,html.vt-arrived.intro-arm .float-actions,
 html.vt-arrived.intro-arm .brand,html.vt-arrived.intro-arm .topbar::after{animation:none}
 
-/* 常用控件的触摸/鼠标按压；不覆盖定位 transform 或已有入场 animation。 */
+/* 常用控件的触摸/鼠标按压；不覆盖定位 transform 或已有入场 animation。
+   面板动作按钮的过渡由 ui-kit.css 持有，保留它的 hover translate。 */
 .topbar .icon-btn,.more-item,.theme-option,.density-option,.settings-close,
-.nsfw-actions button,.feedback-tab,.feedback-progress-filters button,.feedback-progress-intro button,
+.feedback-tab,.feedback-progress-filters button,.feedback-progress-intro button,
 .feedback-public-state button,.feedback-fallback button,.rail-chip{
   transition:background .16s,color .16s,border-color .16s,box-shadow .16s,transform .16s,scale .14s ease;
 }
@@ -2602,7 +2609,7 @@ html.motion-off{scroll-behavior:auto!important}
 }
 .search-filter-close,.search-filter-add,.search-filter-examples button,.search-filter-footer button,
 .search-filter-chip-remove,.update-pop-more,.update-pop-links button,.announcements-tab,.update-row{
-  transition:background .16s,color .16s,border-color .16s,box-shadow .16s,scale .16s ease,filter .16s;
+  transition:background .16s,color .16s,border-color .16s,box-shadow .16s,translate .16s,scale .16s ease,filter .16s;
 }
 .search-filter-form :is(input,select){transition:border-color .16s,box-shadow .16s,background .16s}
 .search-filter-close:active,.search-filter-add:active:not(:disabled),.search-filter-examples button:active,

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -510,8 +510,8 @@ body.dark .codex-door-wrap{border-color:rgba(255,255,255,.1)}
 .search-filter-panel{
   position:absolute;z-index:48;left:50%;top:calc(100% + 10px);width:min(560px,calc(100vw - 24px));
   max-height:min(72vh,620px);overflow:auto;overscroll-behavior:contain;
-  transform:translateX(-50%);border:1px solid var(--popover-line);border-radius:14px;padding:14px;
-  background:var(--panel);
+  transform:translateX(-50%);border:1px solid var(--popover-line);border-radius:18px;padding:16px;
+  background:var(--popover-glass);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);
   box-shadow:var(--popover-shadow);color:var(--text);
 }
 /* 横向居中由 transform 负责；入场只移动独立 translate，避免结束时横跳。 */
@@ -536,12 +536,13 @@ body.dark .codex-door-wrap{border-color:rgba(255,255,255,.1)}
   background:var(--card);color:var(--text);font:inherit;font-size:13px;outline:none;
 }
 .search-filter-form :is(input,select):focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft)}
-.search-filter-form :is(input,select)[aria-invalid="true"]{border-color:#d74b66;box-shadow:0 0 0 3px color-mix(in srgb,#d74b66 12%,transparent)}
+.search-filter-form :is(input,select)[aria-invalid="true"]{border-color:var(--danger);box-shadow:0 0 0 3px color-mix(in srgb,var(--danger) 12%,transparent)}
 .search-filter-add{
-  min-height:36px;border:0;border-radius:9px;padding:0 12px;background:var(--accent);color:#fff;
-  font-size:13px;font-weight:700;white-space:nowrap;
+  min-height:36px;border:1px solid transparent;border-radius:999px;padding:0 16px;background:var(--accent);color:#fff;
+  font-size:13px;font-weight:800;white-space:nowrap;
+  box-shadow:0 8px 22px var(--accent-glow);
 }
-.search-filter-add:hover{filter:brightness(1.05)}
+.search-filter-add:hover:not(:disabled){translate:0 -1px;box-shadow:0 10px 26px color-mix(in srgb,var(--accent) 32%,transparent)}
 .search-filter-add:disabled{cursor:wait;opacity:.65}
 .search-filter-examples{margin-top:14px;padding-top:12px;border-top:1px solid var(--line)}
 .search-filter-examples>span{display:block;color:var(--muted);font-size:12px;font-weight:600}
@@ -554,9 +555,8 @@ body.dark .codex-door-wrap{border-color:rgba(255,255,255,.1)}
 .search-filter-examples button:hover{border-color:var(--accent);background:var(--accent-soft)}
 .search-filter-examples code{font-family:var(--font-mono);font-size:12px;font-weight:600}
 .search-filter-examples small{color:var(--muted);font-size:11px;white-space:nowrap}
-.search-filter-feedback{margin:10px 0 0;color:#c33f59;font-size:12px;line-height:1.5}
+.search-filter-feedback{margin:10px 0 0;color:var(--danger-text);font-size:12px;line-height:1.5}
 .search-filter-feedback:empty{display:none}
-body.dark .search-filter-feedback{color:#ff9e97}
 .search-filter-footer{
   min-height:32px;margin-top:12px;display:flex;align-items:center;justify-content:space-between;gap:12px;
   color:var(--muted);font-size:12px;
@@ -582,7 +582,7 @@ body.dark .search-filter-feedback{color:#ff9e97}
 }
 .filter-btn:hover .filter-icon{background:var(--tagbg);color:var(--text)}
 .filter-btn input:checked + .filter-icon{
-  background:var(--accent-soft);color:var(--accent);box-shadow:inset 0 0 0 1px rgba(21,160,106,.18);
+  background:var(--accent-soft);color:var(--accent);box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--accent) 22%,transparent);
 }
 .filter-btn input:focus-visible + .filter-icon{outline:2px solid var(--accent);outline-offset:2px}
 
@@ -840,7 +840,7 @@ body.dark .data-pill.has-orig{background:rgba(255,255,255,.1)}
   min-height:28px;max-width:100%;border:1px solid color-mix(in srgb,var(--accent) 30%,var(--line));border-radius:999px;
   display:inline-flex;align-items:center;background:var(--accent-soft);color:var(--text);overflow:hidden;
 }
-.search-filter-chip.is-error{border-color:color-mix(in srgb,#d74b66 45%,var(--line));background:color-mix(in srgb,#d74b66 9%,var(--card))}
+.search-filter-chip.is-error{border-color:color-mix(in srgb,var(--danger) 45%,var(--line));background:color-mix(in srgb,var(--danger) 9%,var(--card))}
 .search-filter-chip-label{min-width:0;padding:3px 2px 3px 10px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:12px;font-weight:600}
 .search-filter-chip-remove{
   flex:1;min-width:0;min-height:26px;align-self:stretch;border:0;border-radius:inherit;padding:0;display:flex;align-items:center;text-align:left;
@@ -850,20 +850,15 @@ body.dark .data-pill.has-orig{background:rgba(255,255,255,.1)}
 .search-filter-chip-remove:hover{background:color-mix(in srgb,var(--accent) 12%,transparent);color:var(--accent)}
 .search-filter-chip-remove:focus-visible{outline:none;box-shadow:inset 0 0 0 2px var(--accent);color:var(--accent)}
 .search-filter-chip-remove:is(:hover,:focus-visible) .search-filter-chip-icon{color:var(--accent)}
-.search-clear-all{
-  flex:none;min-height:28px;border:1px solid var(--line);border-radius:999px;padding:3px 10px;
-  background:var(--card);color:var(--accent);font-size:12px;font-weight:600;
-}
-.search-clear-all:hover{border-color:var(--accent);background:var(--accent-soft)}
+.search-clear-all{flex:none}
 .search-status{
   margin:-2px 0 12px;border:1px solid var(--line);border-radius:14px;padding:11px 13px;
   background:var(--panel);color:var(--muted);
 }
-.search-status[data-kind="error"]{border-color:color-mix(in srgb,#d74b66 42%,var(--line));background:color-mix(in srgb,#d74b66 7%,var(--panel))}
+.search-status[data-kind="error"]{border-color:color-mix(in srgb,var(--danger) 42%,var(--line));background:color-mix(in srgb,var(--danger) 7%,var(--panel))}
 .search-status[data-kind="empty"]{border-style:dashed}
 .search-status p{margin:0;font-size:13px;line-height:1.6}
-.search-status[data-kind="error"] p{color:#c33f59}
-body.dark .search-status[data-kind="error"] p{color:#ff9e97}
+.search-status[data-kind="error"] p{color:var(--danger-text)}
 .search-status-actions{display:flex;flex-wrap:wrap;gap:8px;margin-top:9px}
 .search-status-actions:empty{display:none}
 .search-status-actions button{
@@ -900,15 +895,7 @@ body.dark .search-status[data-kind="error"] p{color:#ff9e97}
   border-color:var(--accent);color:var(--accent);background:var(--accent-soft);outline:none;
 }
 .update-filter-controls{display:inline-flex;align-items:center;flex-wrap:wrap;gap:8px}
-.update-filter-btn{
-  display:inline-flex;align-items:center;justify-content:center;gap:6px;
-  min-height:30px;border:1px solid var(--line);border-radius:999px;
-  padding:4px 12px;background:var(--card);color:var(--text);font-size:12px;font-weight:700;
-  transition:border-color .15s,background .15s,color .15s,box-shadow .15s;
-}
-.update-filter-btn:hover{border-color:var(--accent);background:var(--accent-soft);color:var(--accent)}
 .update-filter-btn strong{color:var(--accent);font-weight:900}
-.update-filter-btn[aria-pressed="true"]{border-color:var(--accent);background:var(--accent);color:#fff;box-shadow:0 8px 20px color-mix(in srgb,var(--accent) 18%,transparent)}
 .update-filter-btn[aria-pressed="true"] strong{color:#fff}
 .update-filter-btn.is-latest{border-color:color-mix(in srgb,var(--new) 34%,var(--line));background:color-mix(in srgb,var(--new) 8%,var(--card));box-shadow:0 5px 14px color-mix(in srgb,var(--new) 9%,transparent)}
 .update-filter-btn.is-latest:hover{border-color:var(--new);background:color-mix(in srgb,var(--new) 13%,var(--card));color:var(--text);box-shadow:0 7px 18px color-mix(in srgb,var(--new) 15%,transparent)}
@@ -1125,7 +1112,7 @@ body.dark .badge-char-chip{
 .fav-btn{
   margin-left:auto;flex:none;border:none;background:transparent;cursor:pointer;
   font-size:0;line-height:1;color:var(--muted);padding:2px 5px;border-radius:7px;
-  transition:background .12s,color .12s;
+  transition:background .12s,color .12s,scale .12s ease;
 }
 /* JS 仍写 ★/☆ 文本（verify_ui 断言），这里把字形换成与顶栏同几何的矢量星 */
 .fav-btn::before{
@@ -1133,6 +1120,7 @@ body.dark .badge-char-chip{
   -webkit-mask:var(--ico-star-o) center/contain no-repeat;mask:var(--ico-star-o) center/contain no-repeat;
 }
 .fav-btn.on::before{-webkit-mask-image:var(--ico-star-f);mask-image:var(--ico-star-f)}
+.fav-btn:active{scale:.88}
 .fav-btn:hover{background:var(--tagbg);color:#f5b301}
 .fav-btn.on{color:#f5b301}
 .card.no-img .card-title{font-size:13.8px}
@@ -1223,7 +1211,7 @@ body.density-compact .copy-hint{display:none}
   .masonry.is-relayouting .card,
   .masonry.is-relayouting .card-img-wrap,
   .masonry.is-relayouting .card-tags,
-  .card.card-leaving,
+  .card.card-leaving,.fav-btn,
   .topbar,.sidebar,
   .lightbox,.lightbox-stage,.lightbox-info,.lb-fold,.lb-circle,.lb-fly,#lightboxImg,.lightbox-thumbs,
   .settings-mask,.settings-panel,.sd-badge,.card,.card-img,.toast,.scroll-progress,
@@ -1369,11 +1357,6 @@ body.dark .nsfw-note{color:#ffb4ab;background:rgba(217,45,32,.18)}
 .nsfw-actions{
   display:flex;justify-content:flex-end;gap:9px;margin-top:18px;padding-top:14px;border-top:1px solid var(--line);
 }
-.nsfw-actions button{
-  border:1px solid var(--line);border-radius:999px;padding:9px 15px;
-  font-size:13px;font-weight:800;cursor:pointer;
-  transition:background .12s,border-color .12s,color .12s,transform .12s,box-shadow .12s;
-}
 .nsfw-secondary{background:var(--card);color:var(--muted)}
 .nsfw-secondary:hover{background:var(--tagbg);color:var(--text)}
 .nsfw-primary{
@@ -1424,29 +1407,17 @@ body.dark .nsfw-note{color:#ffb4ab;background:rgba(217,45,32,.18)}
   padding:24px 12px;text-align:center;color:var(--muted);font-size:13px;
   border:1px dashed var(--line);border-radius:14px;background:var(--tagbg);
 }
-/* 动态面板三页签：更新 / 公告 / 反馈。与反馈面板内那对页签同构，样式刻意保持一致 */
-.announcements-tabs{
-  --ann-tab-index:1;position:relative;isolation:isolate;display:grid;grid-template-columns:repeat(3,minmax(0,1fr));
-  gap:4px;background:var(--tagbg);padding:3px;border-radius:12px;margin-bottom:14px;
-}
-.announcements-tabs::before{
-  content:"";position:absolute;z-index:-1;top:3px;bottom:3px;left:3px;
-  width:calc((100% - 14px)/3);border-radius:10px;background:var(--panel);box-shadow:var(--shadow);
-  translate:calc(var(--ann-tab-index) * (100% + 4px)) 0;
-  transition:translate .24s cubic-bezier(.22,1,.36,1);pointer-events:none;
-}
+
+/* 初始标记里选中的是「公告」（第 2 格）；JS 打开面板后再按当前页签改写 --seg-index。 */
+.announcements-tabs{--seg-count:3;--seg-index:1;margin-bottom:14px}
 .announcements-views{position:relative;display:flow-root;min-width:0}
 .announcements-panel{scrollbar-gutter:stable}
-.announcements-tab{
-  flex:1;border:0;background:transparent;color:var(--muted);font-weight:600;font-size:13px;
-  padding:8px;border-radius:10px;cursor:pointer;position:relative;
-  transition:background .15s,color .15s;
-}
-.announcements-tab[aria-selected="true"]{color:var(--text)}
+.announcements-tab{position:relative}
 .announcements-tab-dot{
   display:inline-block;width:6px;height:6px;border-radius:999px;background:var(--new);
   margin-left:5px;vertical-align:1px;font-style:normal;
 }
+.announcements-tab[aria-selected="true"] .announcements-tab-dot{background:#fff}
 .announcements-view-note{margin:0 0 12px;color:var(--muted);font-size:12px;line-height:1.6}
 .updates-list{display:flex;flex-direction:column;gap:4px}
 .update-day{padding-top:6px}
@@ -1497,27 +1468,7 @@ body.dark .nsfw-note{color:#ffb4ab;background:rgba(217,45,32,.18)}
 .feedback-kicker>div{min-width:0}
 .feedback-kicker .settings-title{margin:0}
 .feedback-kicker p{margin:2px 0 0;color:var(--muted);font-size:12px;line-height:1.45}
-.feedback-tabs{
-  position:relative;isolation:isolate;display:grid;grid-template-columns:1fr 1fr;gap:4px;margin:2px 0 12px;padding:4px;
-  border:1px solid var(--line);border-radius:14px;background:var(--tagbg);
-}
-.feedback-tabs::before{
-  content:"";position:absolute;z-index:-1;left:4px;top:4px;bottom:4px;
-  width:calc((100% - 12px)/2);border-radius:10px;background:var(--accent);
-  box-shadow:0 5px 14px var(--accent-glow);pointer-events:none;
-  translate:calc(var(--feedback-tab-index,0) * (100% + 4px)) 0;
-  transition:translate .22s cubic-bezier(.22,1,.36,1);
-}
-.feedback-tab{
-  min-height:38px;border:0;border-radius:10px;background:transparent;color:var(--muted);
-  font-size:13px;font-weight:850;transition:background .15s,color .15s,box-shadow .15s;
-}
-.feedback-tab:hover{color:var(--text);background:var(--card)}
-.feedback-tab[aria-selected="true"]{color:#fff;background:transparent}
-.feedback-tab span{
-  display:inline-grid;min-width:19px;height:19px;margin-left:5px;padding:0 5px;place-items:center;
-  border-radius:999px;background:rgba(255,255,255,.2);font-size:10px;vertical-align:1px;
-}
+.feedback-tabs{margin:2px 0 12px}
 .feedback-tab-panel{min-width:0}
 .feedback-panel .settings-note{margin-bottom:2px;padding:8px 12px}
 .feedback-form{display:flex;flex-direction:column;gap:8px;margin-top:10px}
@@ -1770,8 +1721,6 @@ body.dark .onboarding-scene{background:linear-gradient(135deg,var(--accent-soft)
 .onboarding-dots{display:flex;gap:6px;margin-top:16px}
 .onboarding-dot{width:7px;height:7px;border-radius:50%;background:var(--line)}
 .onboarding-dot.active{background:var(--accent)}
-.onboarding-next{background:var(--accent);box-shadow:0 8px 22px var(--accent-glow)}
-.onboarding-next:hover{box-shadow:0 10px 26px color-mix(in srgb,var(--accent) 32%,transparent)}
 
 /* ---------- R18G / 重口分级 ---------- */
 .set-live.danger{background:linear-gradient(135deg,#dc2626,#7f1d1d)}
@@ -2597,12 +2546,12 @@ html.vt-arrived.intro-arm .brand,html.vt-arrived.intro-arm .topbar::after{animat
 .feedback-field :is(input,select,textarea),.feedback-fallback textarea{transition:border-color .16s,box-shadow .16s,background .16s}
 @media (prefers-reduced-motion:reduce){
   .topbar .icon-btn,.more-item,.theme-option,.density-option,.settings-close,
-  .nsfw-actions button,.feedback-tab,.feedback-progress-filters button,.feedback-progress-intro button,
+  .nsfw-actions button,.feedback-tab,.bar-btn,.panel-action,.feedback-progress-filters button,.feedback-progress-intro button,
   .feedback-public-state button,.feedback-fallback button,.rail-chip,.tree-row,.tw-arrow,
-  .search-scope,.search-scope-label,.feedback-tabs::before,
+  .search-scope,.search-scope-label,.seg-tabs::before,
   .feedback-field :is(input,select,textarea),.feedback-fallback textarea{transition:none!important}
   :is(.topbar .icon-btn,.more-item,.theme-option,.density-option,.settings-close,
-  .nsfw-actions button,.feedback-tab,.feedback-progress-filters button,.feedback-progress-intro button,
+  .nsfw-actions button,.feedback-tab,.bar-btn,.panel-action,.feedback-progress-filters button,.feedback-progress-intro button,
   .feedback-public-state button,.feedback-fallback button,.rail-chip,.tw-arrow):active:not(:disabled),
   .search-scope:active .search-scope-label{scale:1}
 }
@@ -2664,7 +2613,7 @@ html.motion-off{scroll-behavior:auto!important}
 .update-row:hover .update-row-cover{translate:0 -1px}
 .announcements-foot:hover .announcements-foot-arrow{translate:3px 0}
 @media (prefers-reduced-motion: reduce){
-  .search-filter-panel,.updates-popover,.announcements-tabs::before,
+  .search-filter-panel,.updates-popover,
   .search-filter-close,.search-filter-add,.search-filter-examples button,.search-filter-footer button,
   .search-filter-chip-remove,.search-filter-form :is(input,select),.update-pop-more,.update-pop-links button,
   .announcements-tab,.update-row,.update-row-cover,.announcements-foot,.announcements-foot-arrow{

--- a/site/assets/tokens.css
+++ b/site/assets/tokens.css
@@ -18,6 +18,7 @@
   --font-serif:var(--font-display);
   --font-mono:var(--font-prompt);
   --red:var(--new);
+  --danger:#d74b66; --danger-text:#c33f59;
 }
 body.dark{
   --bg:#0b0d13; --panel:#12141d; --card:#161a26; --text:#e8eaf3; --muted:#8a91a6;
@@ -29,6 +30,7 @@ body.dark{
   --popover-shadow:0 20px 54px rgba(0,0,0,.56),0 5px 18px rgba(0,0,0,.34);
   --overlay:rgba(0,0,0,.62);
   --accent-glow:rgba(139,124,248,.22);
+  --danger-text:#ff9e97;
 }
 /* ============ 主题色（换肤）：每套含 light + dark，与深浅色正交；默认紫=base 不加类 ============ */
 body.theme-teal{--bg:#eaeef5;--panel:#ffffff;--card:#ffffff;--text:#22304a;--muted:#7d8aa3;--line:#dbe2ee;--accent:#0fa173;--accent-soft:#dff4ea;--tagbg:#f1f4f9;--tagbg-hover:#e8eef6;--accent-glow:rgba(15,161,115,.18)}

--- a/site/assets/ui-kit.css
+++ b/site/assets/ui-kit.css
@@ -86,5 +86,5 @@
 }
 @media (prefers-reduced-motion:reduce){
   .bar-btn,.panel-action,.seg-tabs>button,.seg-tabs::before{transition:none!important}
-  .bar-btn:active,.panel-action:active,.seg-tabs>button:active{scale:1}
+  .bar-btn:active:not(:disabled),.panel-action:active:not(:disabled),.seg-tabs>button:active:not(:disabled){scale:1}
 }

--- a/site/assets/ui-kit.css
+++ b/site/assets/ui-kit.css
@@ -1,0 +1,90 @@
+/* 跨页共用的界面基件。index.html / strings.html 都在 tokens.css 之后加载本文件，
+   各自的功能样式表只在这之上写差异，不重复几何。
+   新增控件先来这里找同源件；这里没有再谈新增，别在功能样式表里另起一套尺寸。 */
+
+/* ---------- 结果栏按钮家族 ----------
+   这一排里的独立操作按钮共用几何、字重和过渡，各自只留语义色差。
+   新增结果栏入口请加 .bar-btn，不要再另起一套尺寸。 */
+.bar-btn{
+  display:inline-flex;align-items:center;justify-content:center;gap:6px;
+  min-height:30px;border:1px solid var(--line);border-radius:999px;
+  padding:4px 12px;background:var(--card);color:var(--text);
+  font:700 12px/1.25 var(--font-ui);white-space:nowrap;cursor:pointer;
+  transition:border-color .15s,background .15s,color .15s,box-shadow .15s,translate .15s,scale .14s ease;
+}
+.bar-btn:hover{border-color:var(--accent);background:var(--accent-soft);color:var(--accent)}
+.bar-btn:active:not(:disabled){scale:.96}
+.bar-btn.is-on,.bar-btn[aria-pressed="true"]{
+  border-color:var(--accent);background:var(--accent);color:#fff;
+  box-shadow:0 8px 20px color-mix(in srgb,var(--accent) 18%,transparent);
+}
+
+/* ---------- 面板动作按钮 ----------
+   弹层里的动作按钮统一走这里；.nsfw-primary / .nsfw-secondary 是它的语义变体。
+   新面板加按钮请用 .panel-action（主按钮再加 .is-primary）。 */
+.panel-action,.nsfw-actions button{
+  min-height:36px;border:1px solid var(--line);border-radius:999px;padding:9px 15px;
+  font:800 13px/1.25 var(--font-ui);cursor:pointer;
+  transition:background .12s,border-color .12s,color .12s,transform .12s,translate .12s,box-shadow .12s,scale .14s ease;
+}
+/* 底色只给 .panel-action：.nsfw-primary / .nsfw-secondary 的特异度是 (0,1,0)，
+   写进上面那条 (0,1,1) 的共用规则会把它们的红/灰盖掉。几何共用，配色各归各。 */
+.panel-action{background:var(--card);color:var(--text)}
+.panel-action:active:not(:disabled){scale:.96}
+.panel-action:disabled{cursor:not-allowed;opacity:.46;box-shadow:none;translate:none}
+.panel-action:hover:not(:disabled){border-color:var(--accent);background:var(--accent-soft);color:var(--accent)}
+.panel-action.is-primary{
+  border-color:transparent;background:var(--accent);color:#fff;
+  box-shadow:0 8px 22px var(--accent-glow);
+}
+.panel-action.is-sm{min-height:30px;padding:5px 12px;font-size:12px}
+.panel-action.is-danger{border-color:transparent;background:#dc2626;color:#fff;box-shadow:0 8px 22px rgba(217,45,32,.24)}
+.panel-action.is-danger:hover:not(:disabled){
+  background:#dc2626;color:#fff;translate:0 -1px;box-shadow:0 10px 26px rgba(217,45,32,.32);
+}
+.panel-action.is-primary:hover:not(:disabled){
+  background:var(--accent);color:#fff;translate:0 -1px;
+  box-shadow:0 10px 26px color-mix(in srgb,var(--accent) 32%,transparent);
+}
+
+/* ---------- 分段页签 ----------
+   凹槽 + 滑块的分段控件，站内所有页签共用这一种语言。
+   列数写 --seg-count，选中位置写 --seg-index（两个都由 JS 设）。
+   新增页签请用 .seg-tabs，别再造第四套。 */
+.seg-tabs{
+  --seg-count:2;--seg-index:0;
+  position:relative;isolation:isolate;display:grid;
+  grid-template-columns:repeat(var(--seg-count),minmax(0,1fr));
+  gap:4px;padding:4px;border:1px solid var(--line);border-radius:14px;background:var(--tagbg);
+}
+.seg-tabs::before{
+  content:"";position:absolute;z-index:-1;left:4px;top:4px;bottom:4px;
+  width:calc((100% - 8px - (var(--seg-count) - 1) * 4px) / var(--seg-count));
+  border-radius:10px;background:var(--accent);box-shadow:0 5px 14px var(--accent-glow);
+  pointer-events:none;translate:calc(var(--seg-index) * (100% + 4px)) 0;
+  transition:translate .22s cubic-bezier(.22,1,.36,1);
+}
+.seg-tabs>button{
+  min-height:38px;border:0;border-radius:10px;background:transparent;color:var(--muted);
+  font:850 13px/1.25 var(--font-ui);cursor:pointer;
+  transition:background .15s,color .15s,box-shadow .15s,scale .14s ease;
+}
+.seg-tabs>button:hover{color:var(--text);background:var(--card)}
+.seg-tabs>button:is([aria-selected="true"],[aria-checked="true"]){color:#fff;background:transparent}
+.seg-tabs>button:active:not(:disabled){scale:.96}
+/* 页签后面的计数 / 未读点，选中时要在 accent 底上认得出来 */
+.seg-tabs>button>span{
+  display:inline-grid;min-width:19px;height:19px;margin-left:5px;padding:0 5px;place-items:center;
+  border-radius:999px;background:var(--tagbg-hover);color:var(--muted);font-size:10px;vertical-align:1px;
+}
+.seg-tabs>button[aria-selected="true"]>span{background:rgba(255,255,255,.22);color:#fff}
+
+/* 窄屏把动作按钮抬到 44px 触控地板；结果栏按钮本来就常并排换行，保持 30px。 */
+@media (max-width:600px){
+  .panel-action{min-height:44px}
+  .panel-action.is-sm{min-height:38px}
+}
+@media (prefers-reduced-motion:reduce){
+  .bar-btn,.panel-action,.seg-tabs>button,.seg-tabs::before{transition:none!important}
+  .bar-btn:active,.panel-action:active,.seg-tabs>button:active{scale:1}
+}

--- a/site/index.html
+++ b/site/index.html
@@ -51,7 +51,9 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700;900&family=Noto+Serif+SC:wght@400;500;700&family=Outfit:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
 <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700;900&family=Noto+Serif+SC:wght@400;500;700&family=Outfit:wght@400;500;600;700;800;900&display=swap"></noscript>
 <link rel="stylesheet" href="assets/tokens.css">
+<link rel="stylesheet" href="assets/ui-kit.css">
 <link rel="stylesheet" href="assets/styles.css">
+<link rel="stylesheet" href="assets/content-blocking.css">
 <link rel="stylesheet" href="assets/favorites-backup.css">
 <link rel="stylesheet" href="assets/tag-relay.css">
 <link rel="modulepreload" href="assets/data-source.js">
@@ -319,12 +321,12 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
     <aside class="favorites-migration-banner" data-favorites-migration-banner hidden>
       <div class="favorites-migration-banner-copy">
         <b>换到新域名后收藏为空？</b>
-        <span>如果你以前使用 pages.dev 收藏过内容，可以从原浏览器一键找回。</span>
+        <span>如果你以前使用 pages.dev 收藏过内容，可以从原浏览器找回。</span>
         <small data-favorites-migration-feedback hidden></small>
       </div>
       <div class="favorites-migration-banner-actions">
-        <button class="favorites-backup-primary" type="button" data-favorites-migration-start>找回旧收藏</button>
-        <button class="favorites-migration-dismiss" type="button" data-favorites-migration-dismiss aria-label="关闭旧收藏找回提示">以后不提示</button>
+        <button class="panel-action is-primary favorites-backup-primary" type="button" data-favorites-migration-start>找回旧收藏</button>
+        <button class="panel-action favorites-migration-dismiss" type="button" data-favorites-migration-dismiss aria-label="关闭旧收藏找回提示">以后不提示</button>
       </div>
     </aside>
     <div id="codexBanner" class="codex-banner"></div>
@@ -332,13 +334,14 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
     <div class="result-bar">
       <div class="result-bar-head">
         <span id="resultInfo"></span>
-        <button id="searchClearAllBtn" class="search-clear-all" type="button" hidden>清除全部</button>
+        <button id="searchClearAllBtn" class="bar-btn search-clear-all" type="button" hidden>清除全部</button>
       </div>
+      <button id="blockingResultBtn" class="bar-btn blocking-result-btn" type="button">屏蔽管理</button>
       <div id="searchFilterSummary" class="search-filter-summary" hidden>
         <div id="searchFilterChips" class="search-filter-chips" role="list" aria-label="当前搜索筛选"></div>
       </div>
       <div id="updateFilterControls" class="update-filter-controls" hidden></div>
-      <button id="favoritesViewBackupBtn" class="favorites-backup-result-btn favorites-view-backup-btn" type="button" data-favorites-backup-open aria-label="备份与恢复收藏" hidden>
+      <button id="favoritesViewBackupBtn" class="bar-btn favorites-backup-result-btn favorites-view-backup-btn" type="button" data-favorites-backup-open aria-label="备份与恢复收藏" hidden>
         <span class="favorites-view-backup-icon" aria-hidden="true">⇄</span>
         <span>备份与恢复</span>
       </button>
@@ -600,6 +603,13 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <button class="density-option" type="button" data-density="compact" aria-pressed="false">紧凑</button>
       </div>
     </div>
+    <div class="set-row">
+      <div class="set-info">
+        <div class="set-name">内容屏蔽</div>
+        <div id="blockingSettingsSummary" class="set-desc">屏蔽词与单独隐藏的卡片</div>
+      </div>
+      <button id="blockingSettingsBtn" class="panel-action is-sm" type="button">管理</button>
+    </div>
     <div class="set-row nsfw-set-row">
       <div class="set-info">
         <div class="set-name">显示 NSFW 内容 <span class="set-live">需确认</span></div>
@@ -613,6 +623,50 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <div class="set-desc">包含猎奇极端内容</div>
       </div>
       <label class="switch live"><input type="checkbox" id="r18gToggle"><i></i></label>
+    </div>
+  </div>
+</div>
+
+<div id="contentBlocking" class="settings-mask" hidden>
+  <div class="settings-panel blocking-panel" role="dialog" aria-modal="true" aria-labelledby="blockingTitle">
+    <button id="blockingClose" class="settings-close" type="button" aria-label="关闭屏蔽管理">×</button>
+    <h2 id="blockingTitle" class="settings-title">屏蔽管理</h2>
+    <p class="settings-note">清单仅保存在当前浏览器，清除站点数据后会丢失。</p>
+    <div class="blocking-enable-row">
+      <label for="blockingEnabled">启用内容屏蔽</label>
+      <label class="switch live"><input id="blockingEnabled" type="checkbox" checked><i></i></label>
+    </div>
+    <p id="blockingPaused" class="settings-note blocking-paused" role="status" hidden>屏蔽已暂停，清单中的内容会正常显示。</p>
+    <div class="seg-tabs blocking-tabs" role="tablist" aria-label="屏蔽清单">
+      <button id="blockingWordsTab" type="button" role="tab" data-blocking-tab="words" aria-selected="true" aria-controls="blockingWordsPanel">屏蔽词 0</button>
+      <button id="blockingEntriesTab" type="button" role="tab" data-blocking-tab="entries" aria-selected="false" aria-controls="blockingEntriesPanel" tabindex="-1">单独隐藏 0</button>
+    </div>
+    <section id="blockingWordsPanel" role="tabpanel" aria-labelledby="blockingWordsTab">
+      <form id="blockingWordForm" class="blocking-word-form">
+        <label for="blockingWordInput">添加词或短语</label>
+        <div class="blocking-input-row"><input id="blockingWordInput" type="text" maxlength="8000" autocomplete="off" placeholder="例如：蜘蛛，spider" aria-describedby="blockingWordHint blockingWordError"><button class="panel-action is-primary" type="submit">添加</button></div>
+        <p id="blockingWordHint" class="blocking-hint">多个词用逗号分隔。标题或正向提示词命中任意一项即隐藏；英文按整词匹配，中文按短语匹配。</p>
+        <p id="blockingWordError" class="blocking-error" role="alert" hidden></p>
+      </form>
+      <ul id="blockingWordList" class="blocking-word-list" aria-label="已屏蔽的词"></ul>
+      <p id="blockingWordsEmpty" class="blocking-empty">还没有屏蔽词</p>
+    </section>
+    <section id="blockingEntriesPanel" role="tabpanel" aria-labelledby="blockingEntriesTab" hidden>
+      <ul id="blockingEntryList" class="blocking-entry-list" aria-label="单独隐藏的卡片"></ul>
+      <p id="blockingEntriesEmpty" class="blocking-empty">点卡片上的「不想看」，就能在这里管理。</p>
+      <button id="blockingMoreEntries" class="panel-action is-sm" type="button" hidden>显示更多</button>
+    </section>
+  </div>
+</div>
+<div id="blockingReveal" class="settings-mask" hidden>
+  <div class="settings-panel blocking-reveal-panel" role="dialog" aria-modal="true" aria-labelledby="blockingRevealTitle">
+    <button id="blockingRevealClose" class="settings-close" type="button" aria-label="关闭屏蔽提示">×</button>
+    <h2 id="blockingRevealTitle" class="settings-title">此卡片已屏蔽</h2>
+    <p id="blockingRevealReason" class="settings-note"></p>
+    <div class="blocking-reveal-actions">
+      <button id="blockingRevealCancel" class="panel-action" type="button">返回浏览</button>
+      <button id="blockingRevealManage" class="panel-action" type="button">管理屏蔽</button>
+      <button id="blockingRevealOnce" class="panel-action is-primary" type="button">仅本次查看</button>
     </div>
   </div>
 </div>
@@ -678,7 +732,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <b>备份与恢复收藏</b>
         <small>用 JSON 文件搬运法典图鉴与共创广场收藏。</small>
       </div>
-      <button type="button" data-favorites-backup-open>管理备份</button>
+      <button class="panel-action is-sm" type="button" data-favorites-backup-open>管理备份</button>
     </div>
     <div class="history-head">
       <span>最近浏览</span>
@@ -709,8 +763,8 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
             <p>一份文件会同时包含两处收藏。</p>
           </div>
           <div class="favorites-backup-heading-actions">
-            <button id="favoritesExportTextBtn" class="favorites-backup-secondary" type="button">复制迁移文本</button>
-            <button id="favoritesExportBtn" class="favorites-backup-primary" type="button">导出 JSON</button>
+            <button id="favoritesExportTextBtn" class="panel-action favorites-backup-secondary" type="button">复制迁移文本</button>
+            <button id="favoritesExportBtn" class="panel-action is-primary favorites-backup-primary" type="button">导出 JSON</button>
           </div>
         </div>
         <dl class="favorites-backup-stats">
@@ -729,9 +783,9 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <div class="favorites-backup-section-heading">
           <div>
             <h3 id="favoritesMigrationTitle">从旧 pages.dev 找回</h3>
-            <p>在原设备和原浏览器中一键读取旧域收藏，并与当前收藏合并。</p>
+            <p>在原设备和原浏览器中读取旧域收藏，并与当前收藏合并。</p>
           </div>
-          <button class="favorites-backup-primary" type="button" data-favorites-migration-start>一键找回</button>
+          <button class="panel-action is-primary favorites-backup-primary" type="button" data-favorites-migration-start>找回旧收藏</button>
         </div>
         <p class="favorites-migration-feedback" data-favorites-migration-feedback role="status" aria-live="polite" hidden></p>
         <a class="favorites-migration-fallback" data-favorites-migration-fallback href="https://novelai-tag.pages.dev/_favorites-migration-202607.html?bridge=20260721" target="_blank" rel="noopener">自动迁移失败？手动打开救援页下载 JSON</a>
@@ -755,7 +809,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
           <summary>或用文本粘贴</summary>
           <p>把另一台设备复制出的迁移文本粘贴到这里；也接受完整 JSON。</p>
           <textarea id="favoritesImportText" rows="4" spellcheck="false" placeholder="NAITAG1.… 或完整 JSON"></textarea>
-          <button id="favoritesImportTextBtn" class="favorites-backup-secondary" type="button">从文本检查并恢复</button>
+          <button id="favoritesImportTextBtn" class="panel-action favorites-backup-secondary" type="button">从文本检查并恢复</button>
         </details>
 
         <div id="favoritesImportPreview" class="favorites-import-preview" aria-live="polite" hidden>
@@ -782,7 +836,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <p id="favoritesBackupError" class="favorites-backup-error" role="alert" hidden></p>
         <p id="favoritesBackupStatus" class="favorites-backup-status" role="status" aria-live="polite"></p>
       </div>
-      <button id="favoritesRestoreBtn" class="favorites-backup-primary" type="button" disabled>恢复收藏</button>
+      <button id="favoritesRestoreBtn" class="panel-action is-primary favorites-backup-primary" type="button" disabled>恢复收藏</button>
     </footer>
 
     <div id="favoritesReplaceConfirm" class="favorites-replace-confirm" role="alertdialog" aria-modal="true" aria-labelledby="favoritesReplaceTitle" aria-describedby="favoritesReplaceMessage" hidden>
@@ -791,8 +845,8 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <h3 id="favoritesReplaceTitle">确认覆盖当前收藏？</h3>
         <p id="favoritesReplaceMessage">这会同时替换法典图鉴与共创广场收藏。</p>
         <div class="favorites-replace-actions">
-          <button id="favoritesReplaceBack" class="favorites-backup-secondary" type="button">返回检查</button>
-          <button id="favoritesReplaceConfirmBtn" class="favorites-backup-danger" type="button">确认覆盖</button>
+          <button id="favoritesReplaceBack" class="panel-action favorites-backup-secondary" type="button">返回检查</button>
+          <button id="favoritesReplaceConfirmBtn" class="panel-action is-danger favorites-backup-danger" type="button">确认覆盖</button>
         </div>
       </div>
     </div>
@@ -827,7 +881,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
       <span class="panel-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M10 5a2 2 0 0 1 4 0v1a5 5 0 0 1 4 4.9v3.2l1.4 2.4A1 1 0 0 1 18.5 18h-13a1 1 0 0 1-.9-1.5L6 14.1v-3.2A5 5 0 0 1 10 6z"/><path d="M9.5 19a2.5 2.5 0 0 0 5 0"/></svg></span>
       <h2 class="settings-title">动态</h2>
     </div>
-    <div class="announcements-tabs" role="tablist" aria-label="动态分类">
+    <div class="seg-tabs announcements-tabs" role="tablist" aria-label="动态分类">
       <button class="announcements-tab" type="button" role="tab" aria-selected="false" aria-controls="announcementsUpdatesView" tabindex="-1" data-announcements-tab="updates" id="announcementsUpdatesTab">更新<i class="announcements-tab-dot" data-tab-dot="updates" hidden></i></button>
       <button class="announcements-tab" type="button" role="tab" aria-selected="true" aria-controls="announcementsNoticeView" tabindex="0" data-announcements-tab="announcements" id="announcementsNoticeTab">公告<i class="announcements-tab-dot" data-tab-dot="announcements" hidden></i></button>
       <button class="announcements-tab" type="button" role="tab" aria-selected="false" aria-controls="announcementsFeedbackView" tabindex="-1" data-announcements-tab="feedback" id="announcementsFeedbackTab">反馈</button>
@@ -869,7 +923,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <h2 class="settings-title">反馈与进度</h2>
       </div>
     </div>
-    <div class="feedback-tabs" role="tablist" aria-label="反馈功能">
+    <div class="seg-tabs feedback-tabs" role="tablist" aria-label="反馈功能">
       <button id="feedbackSubmitTab" class="feedback-tab" type="button" role="tab" aria-selected="true" aria-controls="feedbackSubmitView" tabindex="0" data-feedback-tab="submit">提交反馈</button>
       <button id="feedbackProgressTab" class="feedback-tab" type="button" role="tab" aria-selected="false" aria-controls="feedbackProgressView" tabindex="-1" data-feedback-tab="progress">处理进度 <span id="feedbackPublicCount" hidden></span></button>
     </div>
@@ -911,7 +965,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <div id="feedbackStatus" class="feedback-status" aria-live="polite"></div>
         <div class="nsfw-actions">
           <button id="feedbackCancel" class="nsfw-secondary" type="button">取消</button>
-          <button id="feedbackSubmit" class="nsfw-primary feedback-submit" type="submit">提交反馈</button>
+          <button id="feedbackSubmit" class="panel-action is-primary feedback-submit" type="submit">提交反馈</button>
         </div>
       </form>
     </section>
@@ -936,7 +990,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
 </div>
 
 <div id="onboarding" class="settings-mask" hidden>
-  <div class="settings-panel onboarding-panel" role="dialog" aria-modal="true" aria-label="快速引导">
+  <div class="settings-panel onboarding-panel" role="dialog" aria-modal="true" aria-label="首次引导">
     <div class="onboarding-top">
       <span id="onboardingStep" class="onboarding-step">1 / 4</span>
       <button id="onboardingSkip" class="onboarding-skip" type="button">跳过</button>
@@ -956,7 +1010,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
     </div>
     <div class="nsfw-actions">
       <button id="onboardingBack" class="nsfw-secondary" type="button" disabled>上一步</button>
-      <button id="onboardingNext" class="nsfw-primary onboarding-next" type="button">下一步</button>
+      <button id="onboardingNext" class="panel-action is-primary onboarding-next" type="button">下一步</button>
     </div>
   </div>
 </div>
@@ -995,6 +1049,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <button id="viewOriginal" type="button">查看原图</button>
         <button id="shareLightbox" type="button">分享</button>
         <button id="reportLightbox" type="button">反馈此图</button>
+        <button id="hideLightbox" type="button">不想看</button>
       </div>
       <div class="lightbox-section">
         <div class="section-head">
@@ -1043,6 +1098,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <span class="badge-neg-chip" hidden title="含负面提示词">负面</span>
         <span class="badge-char-chip" hidden title="含角色词">角色词</span>
         <button class="fav-btn" type="button" title="收藏" aria-label="收藏">☆</button>
+        <button class="hide-card-btn" type="button" title="不想看" aria-label="不想看，隐藏此卡片"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m3 3 18 18M10.6 10.6a2 2 0 0 0 2.8 2.8M9.9 5.3A11 11 0 0 1 12 5c7 0 10 7 10 7a16 16 0 0 1-3.1 4.2M6.1 6.1A19 19 0 0 0 2 12s3 7 10 7a12 12 0 0 0 5.3-1.3"/></svg></button>
       </div>
       <div class="card-tags"></div>
       <div class="card-foot">

--- a/site/index.html
+++ b/site/index.html
@@ -641,6 +641,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
       <button id="blockingWordsTab" type="button" role="tab" data-blocking-tab="words" aria-selected="true" aria-controls="blockingWordsPanel">屏蔽词 0</button>
       <button id="blockingEntriesTab" type="button" role="tab" data-blocking-tab="entries" aria-selected="false" aria-controls="blockingEntriesPanel" tabindex="-1">单独隐藏 0</button>
     </div>
+    <div class="blocking-views">
     <section id="blockingWordsPanel" role="tabpanel" aria-labelledby="blockingWordsTab">
       <form id="blockingWordForm" class="blocking-word-form">
         <label for="blockingWordInput">添加词或短语</label>
@@ -656,6 +657,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
       <p id="blockingEntriesEmpty" class="blocking-empty">点卡片上的「不想看」，就能在这里管理。</p>
       <button id="blockingMoreEntries" class="panel-action is-sm" type="button" hidden>显示更多</button>
     </section>
+    </div>
   </div>
 </div>
 <div id="blockingReveal" class="settings-mask" hidden>

--- a/site/strings.html
+++ b/site/strings.html
@@ -16,6 +16,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700&family=Noto+Serif+SC:wght@400;500;700&family=Outfit:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
 <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;700&family=Noto+Serif+SC:wght@400;500;700&family=Outfit:wght@400;500;600;700;800;900&display=swap"></noscript>
 <link rel="stylesheet" href="assets/tokens.css">
+<link rel="stylesheet" href="assets/ui-kit.css">
 <link rel="stylesheet" href="assets/community.css">
 <link rel="stylesheet" href="assets/favorites-backup.css">
 <link rel="modulepreload" href="assets/community/constants.js">
@@ -85,12 +86,12 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
   <aside class="favorites-migration-banner" data-favorites-migration-banner hidden>
     <div class="favorites-migration-banner-copy">
       <b>换到新域名后收藏为空？</b>
-      <span>如果你以前使用 pages.dev 收藏过内容，可以从原浏览器一键找回。</span>
+      <span>如果你以前使用 pages.dev 收藏过内容，可以从原浏览器找回。</span>
       <small data-favorites-migration-feedback hidden></small>
     </div>
     <div class="favorites-migration-banner-actions">
-      <button class="favorites-backup-primary" type="button" data-favorites-migration-start>找回旧收藏</button>
-      <button class="favorites-migration-dismiss" type="button" data-favorites-migration-dismiss aria-label="关闭旧收藏找回提示">以后不提示</button>
+      <button class="panel-action is-primary favorites-backup-primary" type="button" data-favorites-migration-start>找回旧收藏</button>
+      <button class="panel-action favorites-migration-dismiss" type="button" data-favorites-migration-dismiss aria-label="关闭旧收藏找回提示">以后不提示</button>
     </div>
   </aside>
   <section class="community-hero" aria-labelledby="communityTitle">
@@ -129,7 +130,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
 
     <div class="community-result-row">
       <div id="resultInfo" class="result-bar">正在加载共创广场…</div>
-      <button class="favorites-backup-result-btn" type="button" data-favorites-backup-open>收藏备份</button>
+      <button class="bar-btn favorites-backup-result-btn" type="button" data-favorites-backup-open>收藏备份</button>
     </div>
 
     <button class="submit-inline" type="button" data-open-submit>
@@ -245,8 +246,8 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
             <p>一份文件会同时包含两处收藏。</p>
           </div>
           <div class="favorites-backup-heading-actions">
-            <button id="favoritesExportTextBtn" class="favorites-backup-secondary" type="button">复制迁移文本</button>
-            <button id="favoritesExportBtn" class="favorites-backup-primary" type="button">导出 JSON</button>
+            <button id="favoritesExportTextBtn" class="panel-action favorites-backup-secondary" type="button">复制迁移文本</button>
+            <button id="favoritesExportBtn" class="panel-action is-primary favorites-backup-primary" type="button">导出 JSON</button>
           </div>
         </div>
         <dl class="favorites-backup-stats">
@@ -265,9 +266,9 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <div class="favorites-backup-section-heading">
           <div>
             <h3 id="favoritesMigrationTitle">从旧 pages.dev 找回</h3>
-            <p>在原设备和原浏览器中一键读取旧域收藏，并与当前收藏合并。</p>
+            <p>在原设备和原浏览器中读取旧域收藏，并与当前收藏合并。</p>
           </div>
-          <button class="favorites-backup-primary" type="button" data-favorites-migration-start>一键找回</button>
+          <button class="panel-action is-primary favorites-backup-primary" type="button" data-favorites-migration-start>找回旧收藏</button>
         </div>
         <p class="favorites-migration-feedback" data-favorites-migration-feedback role="status" aria-live="polite" hidden></p>
         <a class="favorites-migration-fallback" data-favorites-migration-fallback href="https://novelai-tag.pages.dev/_favorites-migration-202607.html?bridge=20260721" target="_blank" rel="noopener">自动迁移失败？手动打开救援页下载 JSON</a>
@@ -291,7 +292,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
           <summary>或用文本粘贴</summary>
           <p>把另一台设备复制出的迁移文本粘贴到这里；也接受完整 JSON。</p>
           <textarea id="favoritesImportText" rows="4" spellcheck="false" placeholder="NAITAG1.… 或完整 JSON"></textarea>
-          <button id="favoritesImportTextBtn" class="favorites-backup-secondary" type="button">从文本检查并恢复</button>
+          <button id="favoritesImportTextBtn" class="panel-action favorites-backup-secondary" type="button">从文本检查并恢复</button>
         </details>
 
         <div id="favoritesImportPreview" class="favorites-import-preview" aria-live="polite" hidden>
@@ -318,7 +319,7 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <p id="favoritesBackupError" class="favorites-backup-error" role="alert" hidden></p>
         <p id="favoritesBackupStatus" class="favorites-backup-status" role="status" aria-live="polite"></p>
       </div>
-      <button id="favoritesRestoreBtn" class="favorites-backup-primary" type="button" disabled>恢复收藏</button>
+      <button id="favoritesRestoreBtn" class="panel-action is-primary favorites-backup-primary" type="button" disabled>恢复收藏</button>
     </footer>
 
     <div id="favoritesReplaceConfirm" class="favorites-replace-confirm" role="alertdialog" aria-modal="true" aria-labelledby="favoritesReplaceTitle" aria-describedby="favoritesReplaceMessage" hidden>
@@ -327,8 +328,8 @@ if('scrollRestoration' in history)history.scrollRestoration='manual';</script>
         <h3 id="favoritesReplaceTitle">确认覆盖当前收藏？</h3>
         <p id="favoritesReplaceMessage">这会同时替换法典图鉴与共创广场收藏。</p>
         <div class="favorites-replace-actions">
-          <button id="favoritesReplaceBack" class="favorites-backup-secondary" type="button">返回检查</button>
-          <button id="favoritesReplaceConfirmBtn" class="favorites-backup-danger" type="button">确认覆盖</button>
+          <button id="favoritesReplaceBack" class="panel-action favorites-backup-secondary" type="button">返回检查</button>
+          <button id="favoritesReplaceConfirmBtn" class="panel-action is-danger favorites-backup-danger" type="button">确认覆盖</button>
         </div>
       </div>
     </div>

--- a/tools/README.md
+++ b/tools/README.md
@@ -28,6 +28,7 @@
 | `preview_server.py` | 本地预览 `site/`（带 no-store + `/originals/` 映射；`/share/` 深链只发 App 外壳，验 OG 卡片请用 wrangler pages dev） | 只读网络服务 |
 | `preview_blocking.py` | 屏蔽试用分支的双击预览入口；读取工作区 launch 登记，复用或启动本 worktree 的预览服务 | 只读本地服务，打开浏览器；不启动编辑器 |
 | `test_content_blocking.mjs` | 屏蔽词边界、角色/套图正向、稳定身份兼容、保存/恢复/暂停与存储异常回归 | 只读，使用内存测试存储 |
+| `test_blocking_manager_motion.mjs` | 屏蔽清单节点复用、退场隔离、焦点、快速切页/关闭、跨标签更新与动效兜底回归 | 只读，内存 DOM/动画与存储夹具；真实几何仍须浏览器验证 |
 | `verify_ui.py` | 浏览器 UI 冒烟/视觉回归（报告在 `output/ui-regression/`） | 只读，写测试输出 |
 | `benchmark_search_v1.mjs` | 搜索 V1 与旧匹配逻辑的本地中位耗时对比；数据缺失时明确 SKIP | 只读 |
 | `sd_metadata_inspector.py` | 读图片生成参数 + 审计法典 tag 覆盖率；**图片参数解析的唯一公共入口**，格式与审计流程见下方“操作说明去向” | 只读；审计写 CSV |

--- a/tools/README.md
+++ b/tools/README.md
@@ -26,6 +26,8 @@
 | `build_share_index.py` | 重建分享卡索引 `site/data/share*`（数据/配图变更后；发布数据链自动跑，程序链不碰数据）。校验分书与书目 `entryAliases` 一致并为合并词条保留旧分享键（对象 ID 保留规范目标、别名不计数）；安全本里的门控词条只入词条名；整本 NSFW 的书连词条名都不出（开关 `TITLE_ONLY_NSFW_BOOKS`，默认关） | 会改 share 索引 |
 | `check_cache_buster.py` | 守卫：确认 JS/CSS 无 `?v=` 缓存号残留（改 JS/CSS 后必跑） | 只读 |
 | `preview_server.py` | 本地预览 `site/`（带 no-store + `/originals/` 映射；`/share/` 深链只发 App 外壳，验 OG 卡片请用 wrangler pages dev） | 只读网络服务 |
+| `preview_blocking.py` | 屏蔽试用分支的双击预览入口；读取工作区 launch 登记，复用或启动本 worktree 的预览服务 | 只读本地服务，打开浏览器；不启动编辑器 |
+| `test_content_blocking.mjs` | 屏蔽词边界、角色/套图正向、稳定身份兼容、保存/恢复/暂停与存储异常回归 | 只读，使用内存测试存储 |
 | `verify_ui.py` | 浏览器 UI 冒烟/视觉回归（报告在 `output/ui-regression/`） | 只读，写测试输出 |
 | `benchmark_search_v1.mjs` | 搜索 V1 与旧匹配逻辑的本地中位耗时对比；数据缺失时明确 SKIP | 只读 |
 | `sd_metadata_inspector.py` | 读图片生成参数 + 审计法典 tag 覆盖率；**图片参数解析的唯一公共入口**，格式与审计流程见下方“操作说明去向” | 只读；审计写 CSV |

--- a/tools/preview_blocking.py
+++ b/tools/preview_blocking.py
@@ -1,0 +1,38 @@
+"""Open or start this worktree's local preview using the workspace launch registry."""
+import json
+import threading
+import urllib.error
+import urllib.request
+import webbrowser
+from pathlib import Path
+
+from preview_server import Handler, Server
+
+
+def main():
+    root = Path(__file__).resolve().parent.parent
+    registry = root.parent / '.claude' / 'launch.json'
+    configurations = json.loads(registry.read_text(encoding='utf-8-sig'))['configurations']
+    configuration = next(item for item in configurations if item['name'] == 'fadian-blocking')
+    port = int(configuration['port'])
+    url = f'http://127.0.0.1:{port}/?c=suozhang'
+    try:
+        with urllib.request.urlopen(url, timeout=2) as response:
+            existing = response.read().decode('utf-8')
+        if 'id="contentBlocking"' not in existing:
+            raise RuntimeError('The preview port is used by another service. Check .claude/launch.json.')
+    except (urllib.error.URLError, TimeoutError):
+        with Server(('127.0.0.1', port), Handler) as server:
+            threading.Thread(target=server.serve_forever, daemon=True).start()
+            webbrowser.open(url)
+            print(f'Preview: {url}\nKeep this window open. Press Ctrl+C to stop.')
+            try:
+                threading.Event().wait()
+            except KeyboardInterrupt:
+                server.shutdown()
+    else:
+        webbrowser.open(url)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/test_blocking_manager_motion.mjs
+++ b/tools/test_blocking_manager_motion.mjs
@@ -1,0 +1,204 @@
+// 屏蔽清单的 DOM 身份、焦点与动效生命周期；真实插值由浏览器回归验证。
+import assert from 'node:assert/strict';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { state } from '../site/assets/app/state.js';
+import { BLOCKING_STORAGE_KEY } from '../site/assets/app/content-blocking-core.js';
+import { loadContentBlocking, removeBlockedWord, restoreContentEntry, receiveBlockingStorage } from '../site/assets/app/content-blocking.js';
+import { setupContentBlocking, openBlockingManager } from '../site/assets/app/content-blocking-ui.js';
+
+const allAnimations = [];
+let reduced = false;
+function style() {
+  let values = {};
+  return new Proxy({}, {
+    get: (_, key) => key === 'cssText' ? JSON.stringify(values)
+      : key === 'setProperty' ? (name, value) => { values[name] = value; } : values[key] || '',
+    set: (_, key, value) => { if (key === 'cssText') values = JSON.parse(value || '{}'); else values[key] = value; return true; },
+  });
+}
+class Element extends EventTarget {
+  constructor(tag = 'div', id = '') {
+    super();
+    Object.assign(this, { tag, id, children: [], dataset: {}, attrs: {}, style: style(), hidden: false, inert: false });
+    const classes = new Set();
+    this.classList = {
+      add: name => classes.add(name), remove: name => classes.delete(name), contains: name => classes.has(name),
+      toggle: (name, force) => force ? classes.add(name) : classes.delete(name),
+    };
+  }
+  append(...children) { children.forEach(child => this.insertBefore(child, null)); }
+  insertBefore(child, anchor) {
+    child.remove();
+    this.children.splice(anchor ? this.children.indexOf(anchor) : this.children.length, 0, child);
+    child.parentElement = this;
+  }
+  remove() {
+    if (this.parentElement) this.parentElement.children.splice(this.parentElement.children.indexOf(this), 1);
+    this.parentElement = null;
+  }
+  contains(target) { for (let node = target; node; node = node.parentElement) if (node === this) return true; return false; }
+  get isConnected() { return this === document.body || Boolean(this.parentElement?.isConnected); }
+  set innerHTML(value) {
+    assert.equal(this.tag, 'li', '只在创建单个条目时写模板，不可重建整个清单');
+    const button = new Element('button');
+    if (value.startsWith('<span>')) this.append(new Element('span'), button);
+    else { const labels = new Element('div'); labels.append(new Element('b'), new Element('span')); this.append(labels, button); }
+  }
+  setAttribute(name, value) { this.attrs[name] = String(value); }
+  getAttribute(name) { return this.attrs[name] ?? null; }
+  closest(selector) {
+    assert.equal(selector, '[inert]');
+    for (let node = this; node; node = node.parentElement) if (node.inert) return node;
+    return null;
+  }
+  querySelectorAll(selector) {
+    const matches = node => selector.startsWith('#') ? node.id === selector.slice(1)
+      : selector.startsWith('.') ? node.classList.contains(selector.slice(1))
+        : selector === '[data-blocking-tab]' ? Boolean(node.dataset.blockingTab) : node.tag === selector;
+    const found = [];
+    const visit = node => node.children.forEach(child => { if (matches(child)) found.push(child); visit(child); });
+    visit(this);
+    return found;
+  }
+  querySelector(selector) { return this.querySelectorAll(selector)[0] || null; }
+  focus() { if (this.isConnected && !this.closest('[inert]')) document.activeElement = this; }
+  getBoundingClientRect() {
+    const liveRows = list => list.children.filter(row => row.style.position !== 'absolute');
+    if (this.tag === 'li') {
+      const index = liveRows(this.parentElement).indexOf(this);
+      return { left: 100 + index * 100, top: 200, width: 90, height: 28 };
+    }
+    const height = this.classList.contains('blocking-views')
+      ? (!nodes.blockingWordsPanel.hidden ? 200 + liveRows(nodes.blockingWordList).length * 28 : 40 + liveRows(nodes.blockingEntryList).length * 50)
+      : 100;
+    return { left: 100, top: 200, width: 400, height };
+  }
+  animate(frames, options) {
+    let resolve;
+    let reject;
+    const animation = {
+      element: this, frames, options, cancelled: false,
+      finished: new Promise((yes, no) => { resolve = yes; reject = no; }),
+      cancel() { this.cancelled = true; reject(new Error('cancelled')); },
+      finish: () => resolve(),
+    };
+    allAnimations.push(animation);
+    return animation;
+  }
+}
+
+globalThis.HTMLElement = Element;
+globalThis.MutationObserver = class { observe() {} };
+globalThis.requestAnimationFrame = () => 1;
+globalThis.getComputedStyle = () => ({ opacity: '1', translate: 'none' });
+globalThis.window = { matchMedia: () => ({ matches: reduced }), addEventListener() {} };
+globalThis.document = {
+  body: new Element(), documentElement: new Element(), activeElement: null,
+  querySelector: selector => document.body.querySelector(selector), createElement: tag => new Element(tag), addEventListener() {},
+};
+document.activeElement = document.body;
+const nodes = {};
+const add = (id, parent = document.body, tag = 'div') => { const node = new Element(tag, id); nodes[id] = node; parent.append(node); return node; };
+const mask = add('contentBlocking');
+mask.hidden = true;
+add('blockingReveal').hidden = true;
+const shell = add('blockingViews', mask);
+shell.classList.add('blocking-views');
+const tabs = add('blockingTabs', mask);
+tabs.classList.add('blocking-tabs');
+for (const [kind, title] of [['words', 'Words'], ['entries', 'Entries']]) {
+  const tab = add(`blocking${title}Tab`, tabs, 'button');
+  tab.dataset.blockingTab = kind;
+  const panel = add(`blocking${title}Panel`, shell);
+  add(`blocking${title === 'Words' ? 'Word' : 'Entry'}List`, panel, 'ul');
+  add(`blocking${title}Empty`, panel);
+}
+for (const id of ['blockingWordForm', 'blockingWordInput', 'blockingWordError']) add(id, nodes.blockingWordsPanel);
+add('blockingMoreEntries', nodes.blockingEntriesPanel, 'button');
+for (const id of ['blockingEnabled', 'blockingPaused', 'blockingClose']) add(id, mask);
+for (const id of ['blockingSettingsBtn', 'blockingResultBtn', 'blockingSettingsSummary', 'blockingRevealClose', 'blockingRevealCancel', 'blockingRevealManage']) add(id);
+const storage = new Map();
+globalThis.localStorage = { getItem: key => storage.get(key) || null, setItem: (key, value) => storage.set(key, value) };
+const save = (words, entries = []) => storage.set(BLOCKING_STORAGE_KEY, JSON.stringify({ version: 1, enabled: true, words, entries }));
+save(['alpha', 'beta', 'gamma']);
+state.list = [{}];
+loadContentBlocking();
+setupContentBlocking();
+openBlockingManager();
+const wordRows = () => nodes.blockingWordList.children.filter(row => !row.inert);
+const running = () => allAnimations.filter(animation => !animation.cancelled);
+const flush = async () => { for (let i = 0; i < 8; i += 1) await Promise.resolve(); };
+
+const [alpha, beta, gamma] = wordRows();
+beta.querySelector('button').focus();
+removeBlockedWord('alpha');
+assert.deepEqual(wordRows(), [beta, gamma], '未删除的节点保持身份');
+assert.equal(document.activeElement, beta.querySelector('button'), '未删除的按钮保持焦点');
+assert.equal(alpha.inert, true);
+assert.equal(alpha.getAttribute('aria-hidden'), 'true');
+assert.equal(alpha.querySelector('button').dataset.removeWord, undefined);
+assert.equal(alpha.querySelector('button').disabled, true);
+assert.equal(running().find(animation => animation.element === beta).frames[0].translate, '100px 0px', '余项从之前的位置补位');
+const stale = [...running()];
+removeBlockedWord('beta');
+assert.equal(alpha.isConnected, false, '快速删除先收掉上一轮残影');
+assert.equal(document.activeElement, gamma.querySelector('button'), '删除焦点项后落到相邻项');
+stale.forEach(animation => animation.finish());
+await flush();
+assert.equal(gamma.isConnected, true, '上一轮回调不能移除新一轮保留项');
+
+nodes.blockingEntriesTab.onclick();
+const firstSwitch = [...running()];
+assert.equal(nodes.blockingWordsPanel.inert, true, '离流的旧页立即退出焦点循环');
+assert.equal(nodes.blockingWordsPanel.hidden, false, '普通模式保留短暂视觉退场');
+assert.ok(firstSwitch.some(animation => animation.element === shell && animation.frames[0].height !== animation.frames[1].height));
+nodes.blockingWordsTab.onclick();
+firstSwitch.forEach(animation => animation.finish());
+await flush();
+assert.equal(nodes.blockingWordsPanel.hidden, false, '快速切回后旧轮不能收起当前页');
+assert.equal(nodes.blockingWordsPanel.inert, false);
+nodes.blockingClose.onclick();
+assert.equal(running().length, 0, '关闭结清所有局部动画');
+assert.equal(shell.style.overflow, '');
+openBlockingManager();
+assert.equal(wordRows()[0], gamma, '重开复用节点且不残留前一轮样式');
+
+gamma.querySelector('button').focus();
+save(['delta']);
+receiveBlockingStorage({ key: BLOCKING_STORAGE_KEY, storageArea: localStorage });
+assert.equal(document.activeElement, wordRows()[0].querySelector('button'), '外部更新删除焦点项后提供可操作的替代焦点');
+await sleep(350);
+assert.equal(gamma.isConnected, false, '动画时间线冻结时仍由计时兜底回收');
+assert.equal(running().length, 0);
+assert.equal(shell.style.overflow, '');
+
+for (const mode of ['reduce', 'motion-off']) {
+  reduced = mode === 'reduce';
+  document.documentElement.classList.toggle('motion-off', mode === 'motion-off');
+  nodes.blockingEntriesTab.onclick();
+  assert.equal(nodes.blockingWordsPanel.hidden, true, `${mode} 直接隐藏旧页`);
+  assert.equal(running().length, 0, `${mode} 不建立 WAAPI 动画`);
+  nodes.blockingWordsTab.onclick();
+}
+wordRows()[0].querySelector('button').focus();
+removeBlockedWord('delta');
+assert.equal(nodes.blockingWordList.children.length, 0, '关闭动效时删除直接终态，无残影');
+assert.equal(document.activeElement, nodes.blockingWordInput, '最后一项删除后回到添加入口');
+reduced = false;
+document.documentElement.classList.remove('motion-off');
+save([], ['first', 'second'].map(key => ({ key: `book:${key}`, codexId: 'book', title: key, codexTitle: 'Book' })));
+receiveBlockingStorage({ key: BLOCKING_STORAGE_KEY, storageArea: localStorage });
+nodes.blockingEntriesTab.onclick();
+const [firstEntry, secondEntry] = nodes.blockingEntryList.children;
+firstEntry.querySelector('button').focus();
+restoreContentEntry('book:first');
+assert.equal(firstEntry.inert, true);
+assert.equal(firstEntry.querySelector('button').dataset.restoreEntry, undefined, '恢复后残影不可重复提交');
+assert.equal(nodes.blockingEntryList.children[0], secondEntry, '恢复条目复用剩余行');
+assert.equal(document.activeElement, secondEntry.querySelector('button'));
+restoreContentEntry('book:second');
+assert.equal(document.activeElement, nodes.blockingEntriesTab, '恢复末项后回到页签');
+await sleep(350);
+assert.equal(nodes.blockingEntryList.children.length, 0);
+assert.equal(running().length, 0);
+console.log('blocking manager: keyed nodes, FLIP intent, inert exits, focus, rapid tabs, close/reopen, storage, timeout and reduced motion passed');

--- a/tools/test_content_blocking.mjs
+++ b/tools/test_content_blocking.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import {
+  BLOCKING_STORAGE_KEY, normalizeBlockingPreferences, compileBlockedWords, positiveBlockingFields, matchBlockedWord,
+} from '../site/assets/app/content-blocking-core.js';
+import { state } from '../site/assets/app/state.js';
+import {
+  loadContentBlocking, getBlockingPreferences, addBlockedWords, hideContentEntry, restoreContentEntry,
+  contentBlockReason, isContentBlocked, setContentBlockingEnabled, removeBlockedWord,
+  receiveBlockingStorage, invalidateBlockingEntry,
+} from '../site/assets/app/content-blocking.js';
+
+const match = (word, entry) => matchBlockedWord(positiveBlockingFields(entry), compileBlockedWords([word]));
+assert.equal(match('male', { tags: 'female, smile' }), '', '整词匹配不能误伤 female');
+assert.equal(match('male', { tags: '{male}, solo' }), 'male');
+assert.equal(match('blue eyes', { tags: '1.2::BLUE_EYES::' }), 'blue eyes');
+assert.equal(match('蜘蛛', { title: '机械蜘蛛' }), '蜘蛛');
+assert.equal(match('blood', { negative: 'blood', note: 'blood', path: ['blood'], tags: 'smile' }), '');
+assert.equal(match('blood', { characterPrompts: [{ prompt: 'smile', negative: 'blood' }] }), '');
+assert.equal(match('blood', { characterPrompts: [{ prompt: 'blood' }] }), 'blood');
+assert.equal(match('blood', { images: [{ rawTag: 'smile' }, { rawTag: 'blood', negative: 'other' }] }), 'blood');
+assert.equal(match('blood', { images: [{ negative: 'blood' }] }), '');
+assert.equal(match('blue eyes', { title: 'blue', tags: 'eyes' }), '', '短语不能跨字段拼接');
+assert.equal(match('a.b', { tags: 'axb' }), '', '屏蔽词必须按字面解释');
+assert.equal(match('a.b', { tags: 'a.b' }), 'a.b');
+assert.deepEqual(normalizeBlockingPreferences({ version: 1, words: ['ＢＬＵＥ_ＥＹＥＳ', 'blue eyes', 3] }).words, ['blue eyes']);
+assert.deepEqual(normalizeBlockingPreferences({ version: 99, words: ['test'] }).words, []);
+assert.doesNotThrow(() => normalizeBlockingPreferences({ version: 1, entries: [null, {}, { key: 'a' }, { key: 'a' }] }));
+
+const storage = new Map();
+globalThis.localStorage = {
+  getItem: key => storage.get(key) ?? null,
+  setItem: (key, value) => storage.set(key, value),
+};
+state.codexes = [{ id: 'book', title: '书', aliases: ['old'], entryAliases: { 'book-2': 'book-1' } }, { id: 'other', title: '另一册' }];
+state.codex = state.codexes[0];
+loadContentBlocking();
+const entry = { id: 'book-1', title: '测试', tags: 'smile', path: [] };
+const saved = hideContentEntry(entry);
+assert.equal(saved.ok, true);
+assert.equal(isContentBlocked(entry), true);
+assert.equal(isContentBlocked({ ...entry, id: 'book-2' }), true, '旧 ID 合并后仍屏蔽');
+assert.equal(isContentBlocked({ ...entry, _srcCodexId: 'book' }), true, '跨书搜索和收藏回溯真实来源');
+assert.equal(isContentBlocked({ ...entry, _srcCodexId: 'other' }), false, '不同书同名 ID 不误伤');
+assert.equal(isContentBlocked({ ...entry, id: 'old-1', _srcCodexId: 'old' }), true, '旧法典别名兼容');
+loadContentBlocking();
+assert.equal(isContentBlocked(entry), true, '刷新后保留');
+setContentBlockingEnabled(false);
+assert.equal(isContentBlocked(entry), false);
+assert.equal(getBlockingPreferences().entries.length, 1, '暂停保留清单');
+setContentBlockingEnabled(true);
+restoreContentEntry(saved.key);
+assert.equal(isContentBlocked(entry), false);
+assert.equal(addBlockedWords('smile， 蜘蛛, SMILE').ok, true);
+assert.equal(contentBlockReason(entry).word, 'smile');
+assert.ok(addBlockedWords('smile').error);
+assert.ok(addBlockedWords('a'.repeat(81)).error);
+assert.ok(addBlockedWords(' ').error);
+removeBlockedWord('smile');
+assert.equal(isContentBlocked(entry), false);
+entry.tags = '蜘蛛';
+invalidateBlockingEntry(entry);
+assert.equal(isContentBlocked(entry), true, '编辑后缓存失效');
+localStorage.setItem(BLOCKING_STORAGE_KEY, JSON.stringify({ version: 1, words: [], entries: [] }));
+receiveBlockingStorage({ key: BLOCKING_STORAGE_KEY, storageArea: localStorage });
+assert.equal(isContentBlocked(entry), false, '跨标签页同步');
+localStorage.setItem = () => { throw new Error('storage denied'); };
+assert.ok(addBlockedWords('smile').error);
+assert.equal(getBlockingPreferences().words.length, 0, '保存失败不得假装成功');
+storage.set(BLOCKING_STORAGE_KEY, 'bad json');
+assert.doesNotThrow(loadContentBlocking);
+console.log('content blocking: matching, aliases, persistence, pause, restore and storage errors passed');

--- a/tools/test_render_ui.mjs
+++ b/tools/test_render_ui.mjs
@@ -1199,6 +1199,7 @@ const { loadAnnouncements } = await import('../site/assets/app/announcements.js'
     '../site/index.html',
     '../site/assets/styles.css',
     '../site/assets/edit.css',
+    '../site/assets/tokens.css',
     './build_local_edition.py',
   ];
   const [
@@ -1219,6 +1220,7 @@ const { loadAnnouncements } = await import('../site/assets/app/announcements.js'
     indexSource,
     stylesSource,
     editCssSource,
+    tokensSource,
     localEditionBuilderSource,
   ] = await Promise.all(paths.map(path => readFile(new URL(path, import.meta.url), 'utf8')));
 
@@ -1311,7 +1313,9 @@ const { loadAnnouncements } = await import('../site/assets/app/announcements.js'
   assert.ok(narrowScopeWidth >= 44, '极窄屏范围按钮必须保留可用点击宽度');
   assert.ok(narrowSearchPadding >= narrowScopeLeft + narrowScopeWidth + 8, '极窄屏输入文字必须与范围按钮保留间距');
   assert.match(narrowSearchInput, /padding-right:92px/, '极窄屏输入文字必须为清空与筛选按钮留位');
-  assert.match(stylesSource, /body\.dark \.search-filter-feedback\{color:#ff9e97\}/);
+  assert.match(stylesSource, /\.search-filter-feedback\{[^}]*color:var\(--danger-text\)/);
+  assert.match(tokensSource, /--danger:#d74b66; --danger-text:#c33f59;/);
+  assert.match(tokensSource, /body\.dark\{[\s\S]*--danger-text:#ff9e97;/);
   assert.match(stylesSource, /@media \(prefers-reduced-motion: reduce\)\{[\s\S]*\.search-filter-panel/);
   assert.match(indexSource, /id="sidebar"[\s\S]*id="sidebarBackdrop"[\s\S]*id="main"/);
   assert.match(stylesSource, /\.sidebar:not\(\.closed\)\+\.sidebar-backdrop\{[\s\S]*z-index:24[\s\S]*touch-action:none/);
@@ -1324,7 +1328,7 @@ const { loadAnnouncements } = await import('../site/assets/app/announcements.js'
   assert.doesNotMatch(railActiveSource, /window\.scroll|scrollIntoView/);
   assert.match(indexSource, /id="updateFilterControls"[^>]*hidden/);
   assert.doesNotMatch(indexSource, /onlyImaged/);
-  assert.match(codexUiSource, /className = `update-filter-btn\$\{filter\.latest \? ' is-latest' : ''\}`/);
+  assert.match(codexUiSource, /className = `bar-btn update-filter-btn\$\{filter\.latest \? ' is-latest' : ''\}`/);
   assert.match(codexUiSource, /if \(filter\.latest\) \{[\s\S]*mark\.textContent = 'NEW'/);
   assert.match(uiSource, /closest\?\.\('\[data-update-filter\]'\)/);
   assert.match(appSource, /entryMatchesUpdateFilter\(entry, updateFilter\)/);
@@ -1393,6 +1397,33 @@ const { loadAnnouncements } = await import('../site/assets/app/announcements.js'
   assert.match(stylesSource, /\.toast\{[\s\S]*max-width:min\(360px,calc\(100vw - 24px\)\)/);
   assert.match(stylesSource, /\.toast\.has-action\{[\s\S]*min-height:44px[\s\S]*padding:4px 6px 4px 14px/);
   assert.match(stylesSource, /\.toast\.has-action \.toast-message\{[^}]*text-overflow:ellipsis[^}]*white-space:nowrap/);
+
+  // ---- 界面基件（ui-kit.css）防漂移 ----
+  const uiKitSource = await readFile(new URL('../site/assets/ui-kit.css', import.meta.url), 'utf8');
+  const stringsSource = await readFile(new URL('../site/strings.html', import.meta.url), 'utf8');
+  // 结果栏按钮、面板动作按钮、分段页签各只有一份定义，两个页面都要加载得到。
+  for (const source of [indexSource, stringsSource]) {
+    assert.match(source, /<link rel="stylesheet" href="assets\/ui-kit\.css">/, '两个页面都必须加载 ui-kit.css');
+  }
+  assert.match(uiKitSource, /\.bar-btn\{[\s\S]*border-radius:999px[\s\S]*font:700 12px/);
+  assert.match(uiKitSource, /\.panel-action,\.nsfw-actions button\{[\s\S]*border-radius:999px[\s\S]*font:800 13px/);
+  // 底色必须单独给 .panel-action：写进上面那条共用规则会盖掉 .nsfw-primary 的语义红。
+  assert.match(uiKitSource, /^\.panel-action\{background:var\(--card\);color:var\(--text\)\}$/m);
+  assert.doesNotMatch(
+    uiKitSource.match(/\.panel-action,\.nsfw-actions button\{[^}]+\}/)?.[0] || '',
+    /background:|(?<!border-)color:/,
+    '共用几何规则里不许写底色',
+  );
+  assert.match(uiKitSource, /\.seg-tabs\{[\s\S]*--seg-count:2;--seg-index:0/);
+  // 三处页签共用同一套凹槽与滑块，不再各写一套。
+  for (const tabs of ['announcements-tabs', 'feedback-tabs', 'blocking-tabs']) {
+    assert.match(indexSource, new RegExp(`class="seg-tabs ${tabs}"`), `${tabs} 必须走 .seg-tabs`);
+  }
+  assert.doesNotMatch(stylesSource, /\.(announcements|feedback)-tabs::before\{/, '页签滑块只在 ui-kit.css 里定义一次');
+  // 改版前遗留的旧品牌绿；accent 派生色只走 --accent-glow 或 color-mix。
+  assert.doesNotMatch(stylesSource, /rgba\(21,\s*160,\s*106/, 'styles.css 不得再出现旧品牌绿');
+  // 危险红是语义色，只留给 NSFW / R18G / 覆盖收藏这类真危险动作。
+  assert.doesNotMatch(indexSource, /id="(feedbackSubmit|onboardingNext)"[^>]*class="nsfw-primary/, '非危险主按钮不得借用 .nsfw-primary');
 }
 
 // 中转站侧栏契约：窄桌面不再硬停靠；所有确认留在侧栏内。

--- a/单项工具/屏蔽功能预览.bat
+++ b/单项工具/屏蔽功能预览.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+cd /d "%~dp0.."
+python tools\preview_blocking.py
+if errorlevel 1 pause
+endlocal
+chcp 936 >nul


### PR DESCRIPTION
新增个人屏蔽功能，用户可隐藏卡片或添加关键词，让不想看的内容从浏览结果中移除。规则仅保存在当前浏览器，支持撤销、暂停、恢复和跨标签页同步，保留原始内容及收藏关系。

- 将屏蔽规则接入图鉴、收藏、全站搜索、最近记录、随机浏览和灯箱；主动打开被屏蔽的内容时可临时查看。
- 统一结果栏按钮、弹层操作和分段页签，并调整相关文案与危险按钮的颜色语义。
- 修复隐藏失败后留空卡、快速换书时记录来源错绑和图片重复显现；补齐卡片补位、清单删除与恢复、页签高度交接和减少动态效果模式。
- 增加屏蔽规则与管理面板的回归测试，以及可双击启动的本地预览入口。

验证：57 项浏览器断言、9 组相关 Node 回归、缓存号守卫、JS 语法与差异检查通过。浏览器验收使用本机 Chromium，覆盖移动尺寸模拟及减少动态效果设置，未覆盖实体手机或生产性能。

已有验证限制：本地数据快照导致 `tools/verify_ui.py` 的 `legacy_artist_entry` 夹具出现 StopIteration，`tools/test_codex_route_compat.mjs` 报「未审计分区：画风组词典」。这两项既有问题仍未修复，本次未重复运行整站全套检查。
